### PR TITLE
fix: Use publishService flag instead of extraArgs

### DIFF
--- a/charts/stable/nginx-ingress/values.yaml.gotmpl
+++ b/charts/stable/nginx-ingress/values.yaml.gotmpl
@@ -1,8 +1,9 @@
 controller:
   replicaCount: 3
-  extraArgs:
-    publish-service: nginx/nginx-ingress-controller
+  publishService:
+    enabled: true
 {{- if .Values.jxRequirements.ingress.tls.enabled }}
+  extraArgs:
 {{- if .Values.jxRequirements.ingress.tls.production }}
     default-ssl-certificate: "jx/tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-p"
 {{- else }}


### PR DESCRIPTION
With extraArgs we have to sort of hardcode the name of the service. With `publishService.enabled` the chart will generate the arg `--publish-service=` correctly.