### PR TITLE
Git secret server pass as url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 .idea
 .DS_Store
+.history

--- a/charts/jx3/jx-build-controller/values.yaml.gotmpl
+++ b/charts/jx3/jx-build-controller/values.yaml.gotmpl
@@ -12,4 +12,4 @@ env:
 {{- if eq .Values.jxRequirements.cluster.provider "eks" }}
   AWS_REGION: {{ .Values.jxRequirements.cluster.region }}
 {{- end }}
-  GIT_SECRET_SERVER: {{ .Values.jxRequirements.cluster.gitServer | replace  "https://" "" | replace  "http://" "" }}
+  GIT_SECRET_SERVER: {{ .Values.jxRequirements.cluster.gitServer }}

--- a/charts/jx3/jx-build-controller/values.yaml.gotmpl
+++ b/charts/jx3/jx-build-controller/values.yaml.gotmpl
@@ -12,4 +12,4 @@ env:
 {{- if eq .Values.jxRequirements.cluster.provider "eks" }}
   AWS_REGION: {{ .Values.jxRequirements.cluster.region }}
 {{- end }}
-  GIT_SECRET_SERVER: {{ .Values.jxRequirements.cluster.gitServer | replace  "https://" "" }}
+  GIT_SECRET_SERVER: {{ .Values.jxRequirements.cluster.gitServer | replace  "https://" "" | replace  "http://" "" }}


### PR DESCRIPTION
Pass GIT_SECRET_SERVER as is so that the git credential store can be created with the correct scheme.
    
Depends on https://github.com/jenkins-x/jx-helpers/pull/132