### PR TITLE
chore: upgrade charts

### DIFF
--- a/charts/jenkins-x/jx-build-templates/defaults.yaml
+++ b/charts/jenkins-x/jx-build-templates/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x-charts/jx-build-templates
-version: 0.0.1475
+version: 0.0.1505

--- a/charts/jenkins-x/jx/defaults.yaml
+++ b/charts/jenkins-x/jx/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jx
-version: 2.0.1143
+version: 2.1.155

--- a/charts/jenkins-x/jxboot-helmfile-resources/defaults.yaml
+++ b/charts/jenkins-x/jxboot-helmfile-resources/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x-charts/jxboot-helmfile-resources
-version: 1.0.25
+version: 1.0.26

--- a/charts/jenkins-x/lighthouse/defaults.yaml
+++ b/charts/jenkins-x/lighthouse/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/lighthouse
-version: 0.0.903
+version: 0.0.906

--- a/charts/jenkins-x/nexus/defaults.yaml
+++ b/charts/jenkins-x/nexus/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x-charts/nexus
-version: 0.1.35
+version: 0.1.37

--- a/charts/jenkins-x/sso-operator/defaults.yaml
+++ b/charts/jenkins-x/sso-operator/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/sso-operator
-version: 1.2.49
+version: 1.2.50

--- a/charts/jx3/jx-cli/defaults.yaml
+++ b/charts/jx3/jx-cli/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jx-cli
-version: 3.0.402
+version: 3.1.116

--- a/charts/jx3/jx-kh-check/defaults.yaml
+++ b/charts/jx3/jx-kh-check/defaults.yaml
@@ -1,3 +1,3 @@
 gitUrl: https://github.com/jenkins-x-plugins/jx-kh-check
-version: 0.0.32
 namespace: kuberhealthy
+version: 0.0.56

--- a/charts/jx3/jx-pipelines-visualizer/defaults.yaml
+++ b/charts/jx3/jx-pipelines-visualizer/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jx-pipelines-visualizer
-version: 0.0.68
+version: 0.0.74

--- a/charts/jx3/slack/defaults.yaml
+++ b/charts/jx3/slack/defaults.yaml
@@ -1,1 +1,1 @@
-version: 0.0.20
+version: 0.0.36


### PR DESCRIPTION
* updated chart [jenkins-x/jx](https://github.com/jenkins-x/jx) from `2.0.1143` to `2.1.155`
* updated chart [jenkins-x/jx-build-templates](https://github.com/jenkins-x-charts/jx-build-templates) from `0.0.1475` to `0.0.1505`
* updated chart [jenkins-x/jxboot-helmfile-resources](https://github.com/jenkins-x-charts/jxboot-helmfile-resources) from `1.0.25` to `1.0.26`
* updated chart [jenkins-x/lighthouse](https://github.com/jenkins-x/lighthouse) from `0.0.903` to `0.0.906`
* updated chart [jenkins-x/nexus](https://github.com/jenkins-x-charts/nexus) from `0.1.35` to `0.1.37`
* updated chart [jenkins-x/sso-operator](https://github.com/jenkins-x/sso-operator) from `1.2.49` to `1.2.50`
* updated chart [jx3/jx-cli](https://github.com/jenkins-x/jx-cli) from `3.0.402` to `3.1.116`
* updated chart [jx3/jx-kh-check](https://github.com/jenkins-x-plugins/jx-kh-check) from `0.0.32` to `0.0.56`
* updated chart [jx3/jx-pipelines-visualizer](https://github.com/jenkins-x/jx-pipelines-visualizer) from `0.0.68` to `0.0.74`
* updated chart jx3/slack from `0.0.20` to `0.0.36`