### PR TITLE
fix: include the release name in helmfile template

### DIFF
--- a/src/Makefile.mk
+++ b/src/Makefile.mk
@@ -58,7 +58,7 @@ fetch: init
 	helm repo add jx http://chartmuseum.jenkins-x.io
 
 	# generate the yaml from the charts in helmfile.yaml and moves them to the right directory tree (cluster or namespaces/foo)
-	helmfile --file helmfile.yaml template --include-crds --output-dir-template /tmp/generate/{{.Release.Namespace}}
+	helmfile --file helmfile.yaml template --include-crds --output-dir-template /tmp/generate/{{.Release.Namespace}}/{{.Release.Name}}
 
 	jx gitops split --dir /tmp/generate
 	jx gitops rename --dir /tmp/generate


### PR DESCRIPTION
To support mutliple releases of the same chart the release name is required in the hemlfile template path, otherwise the latter clobber the first

Example from helmfile

```
- chart: dev/webclients-plugin
  version: 43.0.7
  name: webclients-plugin-43-0-7
  values:
  - jx-values.yaml
- chart: dev/webclients-plugin
  version: 43.0.8
  name: webclients-plugin-43-0-8
  values:
  - jx-values.yaml
- chart: dev/webclients-plugin
  version: 43.0.9
  name: webclients-plugin-43-0-9
  values:
  - jx-values.yaml
```

jx boot prior to this patch runs

`helmfile --file helmfile.yaml template --include-crds --output-dir-template /tmp/generate/{{.Release.Namespace}}`

which writes to the same file

```
Templating release=webclients-plugin-43-0-7, chart=dev/webclients-plugin
wrote /tmp/generate/drivenow-dev/webclients-plugin/templates/plugin-release.yaml

Templating release=webclients-plugin-43-0-8, chart=dev/webclients-plugin
wrote /tmp/generate/drivenow-dev/webclients-plugin/templates/plugin-release.yaml

Templating release=webclients-plugin-43-0-9, chart=dev/webclients-plugin
wrote /tmp/generate/drivenow-dev/webclients-plugin/templates/plugin-release.yaml
```

this patch changes this too

```
Templating release=webclients-plugin-43-0-7, chart=dev/webclients-plugin
wrote /tmp/generate/drivenow-dev/webclients-plugin-43-0-7/webclients-plugin/templates/plugin-release.yaml

Templating release=webclients-plugin-43-0-8, chart=dev/webclients-plugin
wrote /tmp/generate/drivenow-dev/webclients-plugin-43-0-8/webclients-plugin/templates/plugin-release.yaml

Templating release=webclients-plugin-43-0-9, chart=dev/webclients-plugin
wrote /tmp/generate/drivenow-dev/webclients-plugin-43-0-9/webclients-plugin/templates/plugin-release.yaml
```

jx gitops `splt` `rename` and `helmfile move` all cope with this and end up with the following structure in config-root

```
config-root/namespaces/drivenow-dev/webclients-plugin-43-0-7/webclients-plugin/drivenow-webclients-43-0-7-pluginrelease.yaml
config-root/namespaces/drivenow-dev/webclients-plugin-43-0-8/webclients-plugin/drivenow-webclients-43-0-8-pluginrelease.yaml
config-root/namespaces/drivenow-dev/webclients-plugin-43-0-9/webclients-plugin/drivenow-webclients-43-0-9-pluginrelease.yaml
```

i.e the format being `config-root/namespaces/{NS}/{RELEASE}/{CHART}/{FILENAME}.yaml`

@chrismellard  and I were bikeshedding :) over changing `jx gitops helmfile move` to change to one of the following

`config-root/namespaces/{NS}/{CHART}/{RELEASE}/{FILENAME}.yaml`

`config-root/namespaces/{NS}/{RELEASE}/{FILENAME}.yaml`


https://app.slack.com/client/T09NY5SBT/C9LTHT2BB/thread/C9LTHT2BB-1610697297.041800
