### PR TITLE
fix: include the release name in helmfile template

### DIFF
--- a/src/Makefile.mk
+++ b/src/Makefile.mk
@@ -58,11 +58,11 @@ fetch: init
 	helm repo add jx http://chartmuseum.jenkins-x.io
 
 	# generate the yaml from the charts in helmfile.yaml and moves them to the right directory tree (cluster or namespaces/foo)
-	helmfile --file helmfile.yaml template --include-crds --output-dir-template /tmp/generate/{{.Release.Namespace}}
+	helmfile --file helmfile.yaml template --include-crds --output-dir-template /tmp/generate/{{.Release.Namespace}}/{{.Release.Name}}
 
 	jx gitops split --dir /tmp/generate
 	jx gitops rename --dir /tmp/generate
-	jx gitops helmfile move --output-dir config-root --dir /tmp/generate
+	jx gitops helmfile move --output-dir config-root --dir /tmp/generate --dir-includes-release-name
 
 	# convert k8s Secrets => ExternalSecret resources using secret mapping + schemas
 	# see: https://github.com/jenkins-x/jx-secret#mappings


### PR DESCRIPTION
To support mutliple releases of the same chart the release name is required in the hemlfile template path, otherwise the latter clobber the first

Full explanation https://github.com/jenkins-x/jx3-versions/pull/2003

Requires https://github.com/jenkins-x/jx-gitops/pull/527