### PR TITLE
chore: Bump up chartmuseum version

### DIFF
--- a/charts/stable/chartmuseum/defaults.yaml
+++ b/charts/stable/chartmuseum/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://artifacthub.io/packages/helm/choerodon/chartmuseum
-version: 2.4.1
+version: 2.14.2


### PR DESCRIPTION
The minimum version that supports serviceaccount annotations is 2.6.1 (https://github.com/helm/charts/pull/19724/files). We used IRSA to use AWS S3 as storage for chartmuseum. We tested the latest available chart version. The 'stable' repo itself is deprecated, but let's use the latest available version there before switching to another repo.