### PR TITLE
chore: upgrade charts

### DIFF
--- a/charts/jenkins-x/lighthouse/defaults.yaml
+++ b/charts/jenkins-x/lighthouse/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/lighthouse
-version: 0.0.907
+version: 0.0.913

--- a/charts/jx3/jx-build-controller/defaults.yaml
+++ b/charts/jx3/jx-build-controller/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x-plugins/jx-build-controller
-version: 0.0.22
+version: 0.0.25

--- a/charts/jx3/jx-cli/defaults.yaml
+++ b/charts/jx3/jx-cli/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jx-cli
-version: 3.1.125
+version: 3.1.148

--- a/charts/jx3/jx-pipelines-visualizer/defaults.yaml
+++ b/charts/jx3/jx-pipelines-visualizer/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jx-pipelines-visualizer
-version: 0.0.77
+version: 1.0.3

--- a/charts/jx3/jx-preview/defaults.yaml
+++ b/charts/jx3/jx-preview/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jx-preview
-version: 0.0.139
+version: 0.0.143


### PR DESCRIPTION
* updated chart [jenkins-x/lighthouse](https://github.com/jenkins-x/lighthouse) from `0.0.907` to `0.0.913`
* updated chart [jx3/jx-build-controller](https://github.com/jenkins-x-plugins/jx-build-controller) from `0.0.22` to `0.0.25`
* updated chart [jx3/jx-cli](https://github.com/jenkins-x/jx-cli) from `3.1.125` to `3.1.148`
* updated chart [jx3/jx-pipelines-visualizer](https://github.com/jenkins-x/jx-pipelines-visualizer) from `0.0.77` to `1.0.3`
* updated chart [jx3/jx-preview](https://github.com/jenkins-x/jx-preview) from `0.0.139` to `0.0.143`
