### PR TITLE
chore: upgrade charts

### DIFF
--- a/charts/jenkins-x/lighthouse/defaults.yaml
+++ b/charts/jenkins-x/lighthouse/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/lighthouse
-version: 0.0.913
+version: 0.0.915

--- a/charts/jx3/jx-build-controller/defaults.yaml
+++ b/charts/jx3/jx-build-controller/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x-plugins/jx-build-controller
-version: 0.0.25
+version: 0.0.26

--- a/charts/jx3/jx-cli/defaults.yaml
+++ b/charts/jx3/jx-cli/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jx-cli
-version: 3.1.148
+version: 3.1.155

--- a/charts/jx3/jx-preview/defaults.yaml
+++ b/charts/jx3/jx-preview/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jx-preview
-version: 0.0.143
+version: 0.0.144


### PR DESCRIPTION
* updated chart [jenkins-x/lighthouse](https://github.com/jenkins-x/lighthouse) from `0.0.913` to `0.0.915`
* updated chart [jx3/jx-build-controller](https://github.com/jenkins-x-plugins/jx-build-controller) from `0.0.25` to `0.0.26`
* updated chart [jx3/jx-cli](https://github.com/jenkins-x/jx-cli) from `3.1.148` to `3.1.155`
* updated chart [jx3/jx-preview](https://github.com/jenkins-x/jx-preview) from `0.0.143` to `0.0.144`
