### PR TITLE
fix: configure the pipelines-visualizer to access the logs storage

### DIFF
--- a/charts/jx3/jx-pipelines-visualizer/values.yaml.gotmpl
+++ b/charts/jx3/jx-pipelines-visualizer/values.yaml.gotmpl
@@ -43,3 +43,16 @@ serviceAccount:
 {{- else }}
     installed-by: jenkins-x
 {{- end }}
+
+# allow the UI to query the long-term storage directly to find an old pipeline
+{{- if hasKey .Values.jxRequirements "storage" }}
+{{- range .Values.jxRequirements.storage }}
+{{- if eq .name "logs" }}
+config:
+  archivedLogsURLTemplate: >-
+    {{ .url }}{{`/jenkins-x/logs/{{.Owner}}/{{.Repository}}/{{if hasPrefix .Branch "pr"}}{{.Branch | upper}}{{else}}{{.Branch}}{{end}}/{{.Build}}.log`}}
+  archivedPipelinesURLTemplate: >-
+    {{ .url }}{{`/jenkins-x/logs/{{.Owner}}/{{.Repository}}/{{if hasPrefix .Branch "pr"}}{{.Branch | upper}}{{else}}{{.Branch}}{{end}}/{{.Build}}.yaml`}}
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
this will allow the UI to access the long-term storage directly, to view an old pipeline that has been garbage collected in the cluster

related to https://github.com/jenkins-x-plugins/jx-build-controller/pull/11