### PR TITLE
fix: nexus password missing from maven settings xml when using gsm

### DIFF
--- a/charts/jenkins-x/jxboot-helmfile-resources/secret-schema.yaml
+++ b/charts/jenkins-x/jxboot-helmfile-resources/secret-schema.yaml
@@ -22,7 +22,7 @@ spec:
       help: The htpasswd encoded user and password for basic auth ingresses
       retry: true
       template: |-
-        {{ htpasswdExtSecret "secret/data/jx/basic/auth/user" "username" "password" }}
+        {{ htpasswdSecret "jx-basic-auth-user-password" "username" "password" }}
   - name: jenkins-release-gpg
     properties:
     - name: pubring.gpg
@@ -80,33 +80,33 @@ spec:
             <servers>
                 <server>
                     <id>local-nexus</id>
-                    <username>{{ extsecret "secret/data/nexus" "username" | default "admin"}}</username>
-                    <password>{{ extsecret "secret/data/nexus" "password" }}</password>
+                    <username>{{ secret "nexus" "username" | default "admin"}}</username>
+                    <password>{{ secret "nexus" "password" }}</password>
                 </server>
                 <server>
                     <id>nexus</id>
-                    <username>{{ extsecret "secret/data/nexus" "username" | default "admin"}}</username>
-                    <password>{{ extsecret "secret/data/nexus" "password" }}</password>
+                    <username>{{ secret "nexus" "username" | default "admin"}}</username>
+                    <password>{{ secret "nexus" "password" }}</password>
                 </server>
                 <server>
                     <id>chartmuseum</id>
-                    <username>{{ extsecret "secret/data/jx/adminUser" "username" }}</username>
-                    <password>{{ extsecret "secret/data/jx/adminUser" "password" }}</password>
+                    <username>{{ secret "jenkins-x-chartmuseum" "username" }}</username>
+                    <password>{{ secret "jenkins-x-chartmuseum" "password" }}</password>
                 </server>
                 <server>
                     <id>bucketrepo</id>
-                    <username>{{ extsecret "secret/data/jx/adminUser" "username" }}</username>
-                    <password>{{ extsecret "secret/data/jx/adminUser" "password" }}</password>
+                    <username>{{ secret "jenkins-x-bucketrepo" "username" }}</username>
+                    <password>{{ secret "jenkins-x-bucketrepo" "password" }}</password>
                 </server>
                 <server>
                     <id>oss-sonatype-staging</id>
-                    <username>{{ extsecret "secret/data/sonatype" "username" }}</username>
-                    <password>{{ extsecret "secret/data/sonatype" "password" }}</password>
+                    <username>{{ secret "sonatype" "username" }}</username>
+                    <password>{{ secret "sonatype" "password" }}</password>
                 </server>
                 <server>
                     <id>docker.io</id>
-                    <username>{{ extsecret "secret/data/dockerhub" "username" }}</username>
-                    <password>{{ extsecret "secret/data/dockerhub" "password" }}</password>
+                    <username>{{ secret "docker-hub" "username" }}</username>
+                    <password>{{ secret "docker-hub" "password" }}</password>
                 </server>
             </servers>
 
@@ -166,7 +166,7 @@ spec:
                     <properties>
                         <gpg.executable>gpg</gpg.executable>
                         <!-- TODO use: .Parameters.gpg.passphrase when it is always populated -->
-                        <gpg.passphrase>{{ extsecret "secret/data/jenkins/release/gpg" "passphrase" }}</gpg.passphrase>
+                        <gpg.passphrase>{{ secret "gpg" "passphrase" }}</gpg.passphrase>
                     </properties>
                 </profile>
             </profiles>
@@ -237,7 +237,7 @@ spec:
           {{- if secret "jx.container-registry-auth" "password" }}
             {{ secret "jx.container-registry-auth" "url" | default "https://index.docker.io/v1/" | quote }}: {
                 "auth": {{ auth "jx.container-registry-auth" "username" "password" | b64enc | quote}},
-                "email": {{ extsecret "secret/data/jx/container-registry-auth" "email" | default "jenkins-x@googlegroups.com" | quote }}
+                "email": {{ secret "jx.container-registry-auth" "email" | default "jenkins-x@googlegroups.com" | quote }}
             }
           {{- end }}
           {{- if or (eq .Requirements.cluster.gitServer "https://github.com") (eq .Requirements.cluster.gitServer "https://github.com/") }}


### PR DESCRIPTION
reverting a recent change from https://github.com/jenkins-x/jx3-versions/commit/ac3ffb2579791ba8cffa3522267b0b6dde729c80#diff-f428f8a805c29d78b1e8603fa794a1b809f44ab9c54b0b57dc433c183afa920aL84

we'll need to look at enabling the external secret change above again once we re-enable a maven BDD test