### PR TITLE
feat: allow pipelines-visualizer to get pipelineruns from longterm storage

### DIFF
--- a/charts/jx3/jx-pipelines-visualizer/defaults.yaml
+++ b/charts/jx3/jx-pipelines-visualizer/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jx-pipelines-visualizer
-version: 1.1.11
+version: 1.2.0

--- a/charts/jx3/jx-pipelines-visualizer/values.yaml.gotmpl
+++ b/charts/jx3/jx-pipelines-visualizer/values.yaml.gotmpl
@@ -53,6 +53,8 @@ config:
     {{ .url }}{{`/jenkins-x/logs/{{.Owner}}/{{.Repository}}/{{if hasPrefix .Branch "pr"}}{{.Branch | upper}}{{else}}{{.Branch}}{{end}}/{{.Build}}.log`}}
   archivedPipelinesURLTemplate: >-
     {{ .url }}{{`/jenkins-x/logs/{{.Owner}}/{{.Repository}}/{{if hasPrefix .Branch "pr"}}{{.Branch | upper}}{{else}}{{.Branch}}{{end}}/{{.Build}}.yaml`}}
+  archivedPipelineRunsURLTemplate: >-
+    {{ .url }}{{`/jenkins-x/pipelineruns/{{.Namespace}}/{{.Name}}.yaml`}}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
so that we don't get 404 when following links to the dashboard

see https://github.com/jenkins-x-plugins/jx-build-controller/issues/13
and https://github.com/jenkins-x-plugins/jx-build-controller/pull/27
and https://github.com/jenkins-x/jx-pipelines-visualizer/pull/104