### PR TITLE
chore: upgrade kuberhealthy & enable prometheus scraping

### DIFF
--- a/charts/kuberhealthy/kuberhealthy/defaults.yaml
+++ b/charts/kuberhealthy/kuberhealthy/defaults.yaml
@@ -1,3 +1,3 @@
 gitUrl: https://github.com/Comcast/kuberhealthy
-version: 2.2.0
+version: 54
 namespace: kuberhealthy

--- a/charts/kuberhealthy/kuberhealthy/values.yaml.gotmpl
+++ b/charts/kuberhealthy/kuberhealthy/values.yaml.gotmpl
@@ -7,3 +7,6 @@ check:
     enabled: true
   networkConnection:
     enabled: true
+
+prometheus:
+  enabled: true


### PR DESCRIPTION
- upgrade kuberhealthy to the latest version: chart "54" (yes...) and app version 2.4.0 (instead of 2.2.0)
- enable prometheus scraping of kuberhealthy metrics