### PR TITLE
chore: configure grafana & prometheus for alerting

### DIFF
--- a/charts/grafana/grafana/values.yaml.gotmpl
+++ b/charts/grafana/grafana/values.yaml.gotmpl
@@ -12,6 +12,9 @@ grafana.ini:
   analytics:
     reporting_enabled: false
     check_for_updates: false
+  dashboards:
+    # this dashboard is defined in https://github.com/jenkins-x-charts/grafana-dashboard
+    default_home_dashboard_path: /tmp/dashboards/jenkins-x.json
 
 datasources:
   datasources.yaml:
@@ -36,9 +39,30 @@ sidecar:
   dashboards:
     enabled: true
     label: jenkins-x.io/grafana-dashboard
+    searchNamespace: ALL
     folder: /tmp/dashboards
     provider:
       allowUiUpdates: true
+  datasources:
+    enabled: true
+    label: jenkins-x.io/grafana-datasource
+    searchNamespace: ALL
+  notifiers:
+    enabled: true
+    label: jenkins-x.io/grafana-notifier
+    searchNamespace: ALL
+
+notifiers:
+  notifiers.yaml:
+    notifiers:
+      - name: prometheus-alertmanager
+        type: prometheus-alertmanager
+        uid: prometheus-alertmanager
+        org_id: 1
+        is_default: true
+        settings:
+          url: http://prometheus-alertmanager.jx-observability
+    delete_notifiers: []
 
 ingress:
   enabled: true

--- a/charts/jx3/grafana-dashboard/defaults.yaml
+++ b/charts/jx3/grafana-dashboard/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x-charts/grafana-dashboard
-version: 0.0.4
+version: 0.1.0

--- a/charts/prometheus-community/prometheus/values.yaml
+++ b/charts/prometheus-community/prometheus/values.yaml
@@ -12,7 +12,7 @@ server:
 alertmanager:
   enabled: true
   persistentVolume:
-    enabled: false
+    enabled: true
 
 kubeStateMetrics:
   enabled: true
@@ -22,3 +22,48 @@ nodeExporter:
 
 pushgateway:
   enabled: false
+
+serverFiles:
+  alerting_rules.yml:
+    groups:
+      - name: CertManager
+        rules:
+          - alert: CertManagerAbsent
+            annotations:
+              summary: Cert Manager has dissapeared from Prometheus service discovery.
+              description: |
+                New certificates will not be able to be minted, and existing ones can't
+                be renewed until cert-manager is back.
+            expr: absent(up{app="cert-manager"})
+            for: 10m
+            labels:
+              severity: critical
+          - alert: CertManagerCertNotReady
+            annotations:
+              summary: The cert `{{ $labels.name }}` is not ready to serve traffic.
+              description: |
+                This certificate has not been ready to serve traffic for at least 10m.
+                If the cert is being renewed or there is another valid cert, the ingress controller
+                _may_ be able to serve that instead.
+            expr: |
+              max by (name, exported_namespace, namespace, condition) (
+                certmanager_certificate_ready_status{condition!="True"} == 1
+              )
+            for: 10m
+            labels:
+              severity: critical
+          - alert: CertManagerCertExpirySoon
+            annotations:
+              summary: |
+                The cert `{{ $labels.name }}` is {{ $value | humanizeDuration }} from expiry,
+                it should have renewed over a week ago.
+              description: |
+                The domain that this cert covers will be unavailable after {{ $value | humanizeDuration }}.
+                Clients using endpoints that this cert protects will start to fail in {{ $value | humanizeDuration }}.
+            expr: |
+              avg by (exported_namespace, namespace, name) (
+                certmanager_certificate_expiration_timestamp_seconds - time()
+              ) < (21 * 24 * 3600) # 21 days in seconds
+            for: 1h
+            labels:
+              severity: warning


### PR DESCRIPTION
- update grafana-dashboard chart & define a default dashboard (instead of using grafana's own default)
- automatically detect grafana datasources & notifiers stored in ConfigMaps in any namespaces - with the right labels
  - `jenkins-x.io/grafana-datasource`
  - `jenkins-x.io/grafana-notifier`
- setup a default grafana alert notifier to fwd the alert to prometheus alertmanager
- configure a few prometheus alerts for cert-manager
  - certificate not ready
  - certificate will expire in 21 days or less