### PR TITLE
fix: add missing mapping for prometheus helm repository

### DIFF
--- a/charts/repositories.yml
+++ b/charts/repositories.yml
@@ -44,3 +44,6 @@ repositories:
 - prefix: grafana
   urls:
   - https://grafana.github.io/helm-charts
+- prefix: prometheus-community
+  urls:
+  - https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
so that people can write helmfiles referencing the prometheus chart without explicitly referencing the prometheus repository