### PR TITLE
chore: add cd-indicators chart

### DIFF
--- a/charts/jx3/cd-indicators/defaults.yaml
+++ b/charts/jx3/cd-indicators/defaults.yaml
@@ -1,0 +1,2 @@
+gitUrl: https://github.com/jenkins-x/cd-indicators
+version: 0.0.9

--- a/charts/jx3/cd-indicators/secret-schema.yaml
+++ b/charts/jx3/cd-indicators/secret-schema.yaml
@@ -1,0 +1,35 @@
+apiVersion: gitops.jenkins-x.io/v1alpha1
+kind: Schema
+spec:
+  objects:
+  - name: cd-indicators-postgresql-password
+    mandatory: true
+    properties:
+    - name: postgresql-password
+      question: the password for the postgres instance used for the CD Indicators
+      help: The password to login in the postgres instance used by the CD Indicators app
+      minLength: 10
+      maxLength: 20
+      generator: password
+  - name: cd-indicators-grafana-datasource
+    mandatory: true
+    properties:
+    - name: postgres.yaml
+      question: the definition of the postgresql datasource for grafana
+      help: the definition of the postgresql datasource for grafana
+      retry: true
+      template: |-
+        apiVersion: 1
+        datasources:
+          - name: Indicators
+            uid: indicators
+            type: postgres
+            url: {{ extsecret "cd-indicators" "postgresql-host" }}:{{ extsecret "cd-indicators" "postgresql-port" }}
+            database: {{ extsecret "cd-indicators" "postgresql-database" }}
+            user: {{ extsecret "cd-indicators" "postgresql-username" }}
+            secureJsonData:
+              password: {{ extsecret "cd-indicators-postgresql-password" "postgresql-password" | quote }}
+            jsonData:
+              {{- range $k,$v := fromJson (extsecret "cd-indicators" "grafana-datasource-postgresql-json-data") }}
+              {{ $k }}: {{ $v }}
+              {{- end }}

--- a/charts/jx3/cd-indicators/values.yaml
+++ b/charts/jx3/cd-indicators/values.yaml
@@ -1,0 +1,14 @@
+# https://github.com/jenkins-x/cd-indicators/blob/main/charts/cd-indicators/values.yaml
+
+secrets:
+  postgres:
+    password:
+      secretKeyRef:
+        name: cd-indicators-postgresql-password
+
+# embedded postgresql chart
+# https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
+postgresql:
+  existingSecret: cd-indicators-postgresql-password
+  image:
+    tag: 13.1.0-debian-10-r38


### PR DESCRIPTION
add default values and secret schema for https://github.com/jenkins-x/cd-indicators

a few notes:
- the chart has an internal dependency on the postgresql chart (enabled by default)
- the postgresql password is auto-generated (using the secret schema)
- it re-use the existing grafana instance, by providing grafana dashboards and datasources configmap/secrets with the right label
- the chart should be added to the `helmfiles/jx/helmfile.yaml` file in the `jx` namespace (because it needs the `lighthouse-hmac-token` secret)