### PR TITLE
chore: register cd-indicators as an ext lighthouse plugin

### DIFF
--- a/schedulers/default.yaml
+++ b/schedulers/default.yaml
@@ -37,6 +37,11 @@ spec:
       - cat
       - dog
       - pony
+  external_plugins:
+    Replace: true
+    entries:
+    - name: cd-indicators
+      endpoint: "http://cd-indicators.jx.svc.cluster.local/lighthouse/events"
   policy:
     protect_tested: true
   postsubmits:

--- a/schedulers/environment.yaml
+++ b/schedulers/environment.yaml
@@ -36,6 +36,11 @@ spec:
       - heart
       - cat
       - override
+  external_plugins:
+    Replace: true
+    entries:
+    - name: cd-indicators
+      endpoint: "http://cd-indicators.jx.svc.cluster.local/lighthouse/events"
   policy:
     protect_tested: true
   postsubmits:

--- a/schedulers/in-repo.yaml
+++ b/schedulers/in-repo.yaml
@@ -39,6 +39,11 @@ spec:
       - cat
       - dog
       - pony
+  external_plugins:
+    Replace: true
+    entries:
+    - name: cd-indicators
+      endpoint: "http://cd-indicators.jx.svc.cluster.local/lighthouse/events"
   queries:
     - excludedBranches: { }
       included_branches: { }

--- a/schedulers/jx-meta-pipeline.yaml
+++ b/schedulers/jx-meta-pipeline.yaml
@@ -37,6 +37,11 @@ spec:
       - cat
       - dog
       - pony
+  external_plugins:
+    Replace: true
+    entries:
+    - name: cd-indicators
+      endpoint: "http://cd-indicators.jx.svc.cluster.local/lighthouse/events"
   policy:
     protect_tested: true
   postsubmits:


### PR DESCRIPTION
this change registers the https://github.com/jenkins-x/cd-indicators app as an external lighthouse plugin on all default schedulers, so that by default events for all repos using these schedulers will be forwarded by lighthouse (webhooks) to the cd-indicators app, so that we can get pullrequest and deployment events, and graph them in grafana.

note that for the moment, cd-indicators is not deployed by default, which means that lighthouse won't be able to make its http request, and instead of logging at the `info` level (that it forwarded the event to our plugin), it will log at the `error` that the call failed - see https://github.com/jenkins-x/lighthouse/blob/fa1e4e162244df54966d7585260a4be0e2c7fc45/pkg/util/externalplugins.go#L183-L187

ideally we'll install cd-indicators by default, and won't have this issue anymore