### PR TITLE
feat: enable tracing in build-controller

### DIFF
--- a/charts/jx3/jx-build-controller/values.yaml.gotmpl
+++ b/charts/jx3/jx-build-controller/values.yaml.gotmpl
@@ -19,3 +19,5 @@ env:
   {{- end }}
 {{- end }}
   GIT_SECRET_SERVER: {{ .Values.jxRequirements.cluster.gitServer }}
+  TRACES_EXPORTER_TYPE: "jaeger:http:thrift"
+  TRACES_EXPORTER_ENDPOINT: "tempo.jx-observability:14268"


### PR DESCRIPTION
see https://github.com/jenkins-x-plugins/jx-build-controller/pull/28

this enable the "tracing" feature of the build-controller, using our internal grafana/tempo instance.

note that even if the observability stack is not installed, it won't fail: if the endpoint doesn't exist, the feature will just be disabled with a warning msg explaining how to enable it