### PR TITLE
fix: ensure grafana secret checksum won't change every time

### DIFF
--- a/charts/grafana/grafana/values.yaml.gotmpl
+++ b/charts/grafana/grafana/values.yaml.gotmpl
@@ -98,3 +98,7 @@ deploymentStrategy:
 
 testFramework:
   enabled: false
+
+# this fake password is not used (it will be replaced by the password from the external secret)
+# it is only set here to avoid Helm regenerating a random new one each time the templates are rendered
+adminPassword: fakepassword


### PR DESCRIPTION
see https://kubernetes.slack.com/archives/C9MBGQJRH/p1619019594489800?thread_ts=1619019176.489400&cid=C9MBGQJRH

the grafana chart uses a random function for the adminPassword by default, and each time we render the templates we end up with a new password, so a new secret checksum, and a change in the deployment.
this fix sets a static password to avoid this issue.
note that this fake password is never used, because it is replaced by the password from the external secret.