### PR TITLE
feat: support jx-requirements log url with a querystring

### DIFF
--- a/charts/jx3/jx-pipelines-visualizer/values.yaml.gotmpl
+++ b/charts/jx3/jx-pipelines-visualizer/values.yaml.gotmpl
@@ -58,12 +58,19 @@ config:
   {{- if hasKey .Values.jxRequirements "storage" }}
   {{- range .Values.jxRequirements.storage }}
   {{- if eq .name "logs" }}
+    {{- /*
+      Cant use urlJoin with the golang template since it will url escape the template, so use urlJoin to inject a token which is replaced later with the template
+      Also, it appears that the log writer clobbers the path part of the url, so lets do the same here
+    */}}w
+    {{- $urlDict := urlParse .url }}
+    {{- $_ := set $urlDict "path" "/___JX_PATH___" }}
+    {{- $url := urlJoin $urlDict }}
   archivedLogsURLTemplate: >-
-    {{ .url }}{{`/jenkins-x/logs/{{.Owner}}/{{.Repository}}/{{if hasPrefix .Branch "pr"}}{{.Branch | upper}}{{else}}{{.Branch}}{{end}}/{{.Build}}.log`}}
+    {{ $url | replace "/___JX_PATH___" `/jenkins-x/logs/{{.Owner}}/{{.Repository}}/{{if hasPrefix .Branch "pr"}}{{.Branch | upper}}{{else}}{{.Branch}}{{end}}/{{.Build}}.log` }}
   archivedPipelinesURLTemplate: >-
-    {{ .url }}{{`/jenkins-x/logs/{{.Owner}}/{{.Repository}}/{{if hasPrefix .Branch "pr"}}{{.Branch | upper}}{{else}}{{.Branch}}{{end}}/{{.Build}}.yaml`}}
+    {{ $url | replace "/___JX_PATH___" `/jenkins-x/logs/{{.Owner}}/{{.Repository}}/{{if hasPrefix .Branch "pr"}}{{.Branch | upper}}{{else}}{{.Branch}}{{end}}/{{.Build}}.yaml` }}
   archivedPipelineRunsURLTemplate: >-
-    {{ .url }}{{`/jenkins-x/pipelineruns/{{.Namespace}}/{{.Name}}.yaml`}}
+    {{ $url | replace "/___JX_PATH___" `/jenkins-x/pipelineruns/{{.Namespace}}/{{.Name}}.yaml` }}
   {{- end }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
To use minio as log storage, query parameters are required for the log url e.g.

```
  storage:
  - name: logs
    url: s3://jx3?endpoint=minio.minio.svc.cluster.local:9000&disableSSL=true&s3ForcePathStyle=true&region=ignored
  - name: reports
    url: s3://jx3?endpoint=minio.minio.svc.cluster.local:9000&disableSSL=true&s3ForcePathStyle=true&region=ignored
```

The PR uses helms urlParse and urlJoin to place the golang template in the path portion of the url, rather than appending, which ends up placing it as part of the querystring