### PR TITLE
feat: added aws secrets configuration

### DIFF
--- a/charts/external-secrets/kubernetes-external-secrets/values.yaml.gotmpl
+++ b/charts/external-secrets/kubernetes-external-secrets/values.yaml.gotmpl
@@ -50,6 +50,18 @@ serviceAccount:
     iam.gke.io/gcp-service-account: {{ .Values.jxRequirements.cluster.clusterName }}-sm@{{ .Values.jxRequirements.cluster.project }}.iam.gserviceaccount.com
 {{- end }}
 
+{{- if eq .Values.jxRequirements.secretStorage "secretsManager" }}
+env:
+  AWS_REGION: {{ .Values.jxRequirements.cluster.region }}
+
+securityContext:
+  fsGroup: 65534
+
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.project }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-external-secrets
+{{- end }}
+
 podAnnotations:
   prometheus.io/scrape: "true"
   prometheus.io/port: "3001"

--- a/secrets/secretsManager/mapping/secret-mappings.yaml
+++ b/secrets/secretsManager/mapping/secret-mappings.yaml
@@ -1,0 +1,78 @@
+apiVersion: gitops.jenkins-x.io/v1alpha1
+kind: SecretMapping
+spec:
+  defaults:
+    backendType: secretsManager
+  secrets:
+  - name: lighthouse-hmac-token
+    backendType: secretsManager
+    mappings:
+    - name: hmac
+      key: secret/data/lighthouse/hmac
+      property: token
+  - name: lighthouse-oauth-token
+    backendType: secretsManager
+    mappings:
+    - name: oauth
+      key: secret/data/lighthouse/oauth
+      property: token
+  - name: jx-pipeline-git-github-github
+    backendType: secretsManager
+    mappings:
+    - name: username
+      key: secret/data/jx/pipelineUser
+      property: username
+    - name: password
+      key: secret/data/jx/pipelineUser
+      property: token
+  - name: knative-git-user-pass
+    backendType: secretsManager
+    mappings:
+    - name: username
+      key: secret/data/jx/pipelineUser
+      property: username
+    - name: password
+      key: secret/data/jx/pipelineUser
+      property: token
+  - name: knative-docker-user-pass
+    backendType: secretsManager
+    mappings:
+    - name: username
+      key: secret/data/jx/docker
+      property: username
+    - name: password
+      key: secret/data/jx/docker
+      property: password
+  - name: nexus
+    backendType: secretsManager
+    mappings:
+    - name: password
+      key: secret/data/nexus
+      property: password
+  - name: jenkins-x-bucketrepo
+    backendType: secretsManager
+    mappings:
+    - name: BASIC_AUTH_USER
+      key: secret/data/jx/adminUser
+      property: username
+    - name: BASIC_AUTH_PASS
+      key: secret/data/jx/adminUser
+      property: password
+  - name: jenkins-x-chartmuseum
+    backendType: secretsManager
+    mappings:
+    - name: BASIC_AUTH_USER
+      key: secret/data/jx/adminUser
+      property: username
+    - name: BASIC_AUTH_PASS
+      key: secret/data/jx/adminUser
+      property: password
+  - name: jenkins-maven-settings
+    backendType: secretsManager
+    mappings:
+    - name: settings.xml
+      key: secret/data/jx/mavenSettings
+      property: settingsXml
+    - name: settings-security.xml
+      key: secret/data/jx/mavenSettings
+      property: securityXml

--- a/secrets/systemManager/mapping/secret-mappings.yaml
+++ b/secrets/systemManager/mapping/secret-mappings.yaml
@@ -1,0 +1,80 @@
+apiVersion: gitops.jenkins-x.io/v1alpha1
+kind: SecretMapping
+spec:
+  defaults:
+    backendType: asmSecretsManager
+  secrets:
+  - name: lighthouse-hmac-token
+    backendType: vault
+    mappings:
+    - name: hmac
+      key: secret/data/lighthouse/hmac
+      property: token
+  - name: lighthouse-oauth-token
+    backendType: vault
+    mappings:
+    - name: oauth
+      key: secret/data/lighthouse/oauth
+      property: token
+  - name: jx-pipeline-git-github-github
+    backendType: vault
+    mappings:
+    - name: username
+      key: secret/data/jx/pipelineUser
+      property: username
+    - name: password
+      key: secret/data/jx/pipelineUser
+      property: token
+  - name: knative-git-user-pass
+    backendType: vault
+    mappings:
+    - name: username
+      key: secret/data/jx/pipelineUser
+      property: username
+    - name: password
+      key: secret/data/jx/pipelineUser
+      property: token
+  - name: knative-docker-user-pass
+    backendType: vault
+    mappings:
+    - name: username
+      key: secret/data/jx/docker
+      property: username
+    - name: password
+      key: secret/data/jx/docker
+      property: password
+  - name: nexus
+    backendType: vault
+    mappings:
+    - name: password
+      key: secret/data/nexus
+      property: password
+  - name: jenkins-x-bucketrepo
+    backendType: vault
+    mappings:
+    - name: BASIC_AUTH_USER
+      key: secret/data/jx/adminUser
+      property: username
+    - name: BASIC_AUTH_PASS
+      key: secret/data/jx/adminUser
+      property: password
+  - name: jenkins-x-chartmuseum
+    backendType: vault
+    mappings:
+    - name: BASIC_AUTH_USER
+      key: secret/data/jx/adminUser
+      property: username
+    - name: BASIC_AUTH_PASS
+      key: secret/data/jx/adminUser
+      property: password
+  - name: jenkins-maven-settings
+    backendType: vault
+    mappings:
+    - name: settings.xml
+      key: secret/data/jx/mavenSettings
+      property: settingsXml
+    - name: settings-security.xml
+      key: secret/data/jx/mavenSettings
+      property: securityXml
+  defaults:
+    backendType: vault


### PR DESCRIPTION
This commit adds AWS secrets configuration
to the external-secrets chart. Following the chart
documentation

https://github.com/external-secrets/kubernetes-external-secrets/tree/6.3.0/charts/kubernetes-external-secrets#installing-the-chart

A single Jenkins X Service Account role will need to be setup

Also updated mappings for systemManager and secretsManager