### PR TITLE
fix: increase polling interval if we're using Azure Key Vault

### DIFF
--- a/charts/external-secrets/kubernetes-external-secrets/values.yaml.gotmpl
+++ b/charts/external-secrets/kubernetes-external-secrets/values.yaml.gotmpl
@@ -14,6 +14,26 @@ replicaCount: 0
 
 env:
   POLLER_INTERVAL_MILLISECONDS: 60000
+{{- if eq .Values.jxRequirements.secretStorage "secretsManager" }}
+  AWS_REGION: {{ .Values.jxRequirements.cluster.region }}
+
+securityContext:
+  fsGroup: 65534
+
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.project }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-external-secrets-secrets-manager
+{{- end }}
+{{- if eq .Values.jxRequirements.secretStorage "systemManager" }}
+  AWS_REGION: {{ .Values.jxRequirements.cluster.region }}
+
+securityContext:
+  fsGroup: 65534
+
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.project }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-external-secrets-parameter-store
+{{- end }}
 {{- if eq .Values.jxRequirements.secretStorage "vault" }}
   VAULT_ADDR: https://vault.jx-vault:8200
   NODE_EXTRA_CA_CERTS: "/usr/local/share/ca-certificates/ca.crt"
@@ -48,30 +68,6 @@ customClusterRoles:
 serviceAccount:
   annotations:
     iam.gke.io/gcp-service-account: {{ .Values.jxRequirements.cluster.clusterName }}-sm@{{ .Values.jxRequirements.cluster.project }}.iam.gserviceaccount.com
-{{- end }}
-
-{{- if eq .Values.jxRequirements.secretStorage "secretsManager" }}
-env:
-  AWS_REGION: {{ .Values.jxRequirements.cluster.region }}
-
-securityContext:
-  fsGroup: 65534
-
-serviceAccount:
-  annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.project }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-external-secrets-secrets-manager
-{{- end }}
-
-{{- if eq .Values.jxRequirements.secretStorage "systemManager" }}
-env:
-  AWS_REGION: {{ .Values.jxRequirements.cluster.region }}
-
-securityContext:
-  fsGroup: 65534
-
-serviceAccount:
-  annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.project }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-external-secrets-parameter-store
 {{- end }}
 
 podAnnotations:

--- a/charts/external-secrets/kubernetes-external-secrets/values.yaml.gotmpl
+++ b/charts/external-secrets/kubernetes-external-secrets/values.yaml.gotmpl
@@ -12,16 +12,11 @@ crds:
 replicaCount: 0
 {{- end }}
 
-{{- if eq .Values.jxRequirements.secretStorage "azurekeyvault" }}
 env:
   POLLER_INTERVAL_MILLISECONDS: 60000
-{{- end }}
-
 {{- if eq .Values.jxRequirements.secretStorage "vault" }}
-env:
   VAULT_ADDR: https://vault.jx-vault:8200
   NODE_EXTRA_CA_CERTS: "/usr/local/share/ca-certificates/ca.crt"
-  POLLER_INTERVAL_MILLISECONDS: 60000
 
 deploymentInitContainers:
   initContainers:

--- a/charts/external-secrets/kubernetes-external-secrets/values.yaml.gotmpl
+++ b/charts/external-secrets/kubernetes-external-secrets/values.yaml.gotmpl
@@ -12,6 +12,11 @@ crds:
 replicaCount: 0
 {{- end }}
 
+{{- if eq .Values.jxRequirements.secretStorage "azurekeyvault" }}
+env:
+  POLLER_INTERVAL_MILLISECONDS: 60000
+{{- end }}
+
 {{- if eq .Values.jxRequirements.secretStorage "vault" }}
 env:
   VAULT_ADDR: https://vault.jx-vault:8200


### PR DESCRIPTION
The default polling of 1000ms is too short and triggers the rate limiting.