### PR TITLE
chore: configure the lighthouse web ui

### DIFF
--- a/schedulers/default.yaml
+++ b/schedulers/default.yaml
@@ -42,6 +42,8 @@ spec:
     entries:
     - name: cd-indicators
       endpoint: "http://cd-indicators.jx.svc.cluster.local/lighthouse/events"
+    - name: lighthouse-webui-plugin
+      endpoint: "http://lighthouse-webui-plugin.jx.svc.cluster.local/lighthouse/events"
   policy:
     protect_tested: true
   postsubmits:

--- a/schedulers/environment.yaml
+++ b/schedulers/environment.yaml
@@ -41,6 +41,8 @@ spec:
     entries:
     - name: cd-indicators
       endpoint: "http://cd-indicators.jx.svc.cluster.local/lighthouse/events"
+    - name: lighthouse-webui-plugin
+      endpoint: "http://lighthouse-webui-plugin.jx.svc.cluster.local/lighthouse/events"
   policy:
     protect_tested: true
   postsubmits:

--- a/schedulers/in-repo.yaml
+++ b/schedulers/in-repo.yaml
@@ -44,6 +44,8 @@ spec:
     entries:
     - name: cd-indicators
       endpoint: "http://cd-indicators.jx.svc.cluster.local/lighthouse/events"
+    - name: lighthouse-webui-plugin
+      endpoint: "http://lighthouse-webui-plugin.jx.svc.cluster.local/lighthouse/events"
   queries:
     - excludedBranches: { }
       included_branches: { }

--- a/schedulers/jx-meta-pipeline.yaml
+++ b/schedulers/jx-meta-pipeline.yaml
@@ -42,6 +42,8 @@ spec:
     entries:
     - name: cd-indicators
       endpoint: "http://cd-indicators.jx.svc.cluster.local/lighthouse/events"
+    - name: lighthouse-webui-plugin
+      endpoint: "http://lighthouse-webui-plugin.jx.svc.cluster.local/lighthouse/events"
   policy:
     protect_tested: true
   postsubmits:


### PR DESCRIPTION
update the default schedulers to register the lighthouse webui as an external plugin, so that it can receive webhook events from lighthouse-webhooks