### PR TITLE
chore: use the new LH webui when reporting status updates

### DIFF
--- a/schedulers/default.yaml
+++ b/schedulers/default.yaml
@@ -19,7 +19,7 @@ spec:
       skip-unknown-contexts: false
     pr_status_base_url: ""
     squash_label: ""
-    target_url: http://dashboard{{ .Requirements.ingress.namespaceSubDomain }}{{ .Requirements.ingress.domain }}
+    target_url: http://lighthouse{{ .Requirements.ingress.namespaceSubDomain }}{{ .Requirements.ingress.domain }}/merge/status
   plugins:
     entries:
       - approve

--- a/schedulers/environment.yaml
+++ b/schedulers/environment.yaml
@@ -19,7 +19,7 @@ spec:
       skip-unknown-contexts: false
     pr_status_base_url: ""
     squash_label: ""
-    target_url: http://dashboard{{ .Requirements.ingress.namespaceSubDomain }}{{ .Requirements.ingress.domain }}
+    target_url: http://lighthouse{{ .Requirements.ingress.namespaceSubDomain }}{{ .Requirements.ingress.domain }}/merge/status
   plugins:
     entries:
       - config-updater

--- a/schedulers/in-repo.yaml
+++ b/schedulers/in-repo.yaml
@@ -19,7 +19,7 @@ spec:
       skip-unknown-contexts: false
     pr_status_base_url: ""
     squash_label: ""
-    target_url: http://dashboard{{ .Requirements.ingress.namespaceSubDomain }}{{ .Requirements.ingress.domain }}
+    target_url: http://lighthouse{{ .Requirements.ingress.namespaceSubDomain }}{{ .Requirements.ingress.domain }}/merge/status
   # lets look in the source repository for trigger files
   in_repo: true
   plugins:

--- a/schedulers/jx-meta-pipeline.yaml
+++ b/schedulers/jx-meta-pipeline.yaml
@@ -19,7 +19,7 @@ spec:
       skip-unknown-contexts: false
     pr_status_base_url: ""
     squash_label: ""
-    target_url: http://dashboard{{ .Requirements.ingress.namespaceSubDomain }}{{ .Requirements.ingress.domain }}
+    target_url: http://lighthouse{{ .Requirements.ingress.namespaceSubDomain }}{{ .Requirements.ingress.domain }}/merge/status
   plugins:
     entries:
       - approve


### PR DESCRIPTION
related to https://github.com/jenkins-x/lighthouse/pull/1324
instead of using the pipelines visualizer, let's use the new lighthouse webui and its "merge status" page
it might help people understand why keeper is not merging a PR