### PR TITLE
fix: use external secrets name as standard

### DIFF
--- a/charts/external-secrets/kubernetes-external-secrets/values.yaml.gotmpl
+++ b/charts/external-secrets/kubernetes-external-secrets/values.yaml.gotmpl
@@ -32,7 +32,7 @@ securityContext:
 
 serviceAccount:
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.project }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-external-secrets-parameter-store
+    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.project }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-external-secrets-system-manager
 {{- end }}
 {{- if eq .Values.jxRequirements.secretStorage "vault" }}
   VAULT_ADDR: https://vault.jx-vault:8200

--- a/secrets/systemManager/mapping/secret-mappings.yaml
+++ b/secrets/systemManager/mapping/secret-mappings.yaml
@@ -2,22 +2,22 @@ apiVersion: gitops.jenkins-x.io/v1alpha1
 kind: SecretMapping
 spec:
   defaults:
-    backendType: asmSecretsManager
+    backendType: systemManager
   secrets:
   - name: lighthouse-hmac-token
-    backendType: vault
+    backendType: systemManager
     mappings:
     - name: hmac
       key: secret/data/lighthouse/hmac
       property: token
   - name: lighthouse-oauth-token
-    backendType: vault
+    backendType: systemManager
     mappings:
     - name: oauth
       key: secret/data/lighthouse/oauth
       property: token
   - name: jx-pipeline-git-github-github
-    backendType: vault
+    backendType: systemManager
     mappings:
     - name: username
       key: secret/data/jx/pipelineUser
@@ -26,7 +26,7 @@ spec:
       key: secret/data/jx/pipelineUser
       property: token
   - name: knative-git-user-pass
-    backendType: vault
+    backendType: systemManager
     mappings:
     - name: username
       key: secret/data/jx/pipelineUser
@@ -35,7 +35,7 @@ spec:
       key: secret/data/jx/pipelineUser
       property: token
   - name: knative-docker-user-pass
-    backendType: vault
+    backendType: systemManager
     mappings:
     - name: username
       key: secret/data/jx/docker
@@ -44,13 +44,13 @@ spec:
       key: secret/data/jx/docker
       property: password
   - name: nexus
-    backendType: vault
+    backendType: systemManager
     mappings:
     - name: password
       key: secret/data/nexus
       property: password
   - name: jenkins-x-bucketrepo
-    backendType: vault
+    backendType: systemManager
     mappings:
     - name: BASIC_AUTH_USER
       key: secret/data/jx/adminUser
@@ -59,7 +59,7 @@ spec:
       key: secret/data/jx/adminUser
       property: password
   - name: jenkins-x-chartmuseum
-    backendType: vault
+    backendType: systemManager
     mappings:
     - name: BASIC_AUTH_USER
       key: secret/data/jx/adminUser
@@ -68,7 +68,7 @@ spec:
       key: secret/data/jx/adminUser
       property: password
   - name: jenkins-maven-settings
-    backendType: vault
+    backendType: systemManager
     mappings:
     - name: settings.xml
       key: secret/data/jx/mavenSettings
@@ -77,4 +77,4 @@ spec:
       key: secret/data/jx/mavenSettings
       property: securityXml
   defaults:
-    backendType: vault
+    backendType: systemManager


### PR DESCRIPTION
renamed parameter-store to system-manager to maintain standard.
Also updated the mapping file as that still said vault