### PR TITLE
Revert "fix: upgrade to version 3.2.171"

### DIFF
--- a/.lighthouse/jenkins-x/bdd/terraform-bbc.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-bbc.yaml.gotmpl
@@ -20,7 +20,7 @@ spec:
 
 
   terraformRunner: ghcr.io/jenkins-x/terraform-operator-gcp
-  terraformVersion: 3.2.171
+  terraformVersion: 3.2.170
 
   terraformModule:
     address: https://github.com/jx3-gitops-repositories/jx3-terraform-gke

--- a/.lighthouse/jenkins-x/bdd/terraform-bbs.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-bbs.yaml.gotmpl
@@ -29,7 +29,7 @@ spec:
           key: password
 
   terraformRunner: ghcr.io/jenkins-x/terraform-operator-gcp
-  terraformVersion: 3.2.171
+  terraformVersion: 3.2.170
 
   terraformModule:
     address: https://jenkins-x-bdd@bitbucket.beescloud.com/scm/jxbdd/infra-{{ .Env.TF_VAR_cluster_name }}-dev.git

--- a/.lighthouse/jenkins-x/bdd/terraform-eks.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-eks.yaml.gotmpl
@@ -38,7 +38,7 @@ spec:
           key: password
 
   terraformRunner: ghcr.io/jenkins-x/terraform-operator-aws
-  terraformVersion: 3.2.171
+  terraformVersion: 3.2.170
 
   terraformModule:
     address: https://github.com/jenkins-x-bdd/infra-{{ .Env.TF_VAR_cluster_name }}-dev

--- a/.lighthouse/jenkins-x/bdd/terraform-ghe.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-ghe.yaml.gotmpl
@@ -29,7 +29,7 @@ spec:
           key: password
 
   terraformRunner: ghcr.io/jenkins-x/terraform-operator-gcp
-  terraformVersion: 3.2.171
+  terraformVersion: 3.2.170
 
   terraformModule:
     address: https://github.beescloud.com/dev1/infra-{{ .Env.TF_VAR_cluster_name }}-dev

--- a/.lighthouse/jenkins-x/bdd/terraform-gitea.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-gitea.yaml.gotmpl
@@ -16,7 +16,7 @@ spec:
 {{- end }}
 
   terraformRunner: ghcr.io/jenkins-x/terraform-operator-gcp
-  terraformVersion: 3.2.171
+  terraformVersion: 3.2.170
 
   terraformModule:
     address: https://github.com/jx3-gitops-repositories/jx3-terraform-gke

--- a/.lighthouse/jenkins-x/bdd/terraform-gitlab.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-gitlab.yaml.gotmpl
@@ -29,7 +29,7 @@ spec:
           key: password
 
   terraformRunner: ghcr.io/jenkins-x/terraform-operator-gcp
-  terraformVersion: 3.2.171
+  terraformVersion: 3.2.170
 
   terraformModule:
     address: https://jenkins-x-bot-test@gitlab.com/jxbdd/infra-{{ .Env.TF_VAR_cluster_name }}-dev.git

--- a/.lighthouse/jenkins-x/bdd/terraform-kube.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-kube.yaml.gotmpl
@@ -36,7 +36,7 @@ spec:
           key: password
 
   terraformRunner: ghcr.io/jenkins-x/terraform-operator-gcp
-  terraformVersion: 3.2.171
+  terraformVersion: 3.2.170
 
   terraformModule:
     address: https://github.com/jenkins-x/learn-terraform-provision-gke-cluster

--- a/.lighthouse/jenkins-x/bdd/terraform-kubevault.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-kubevault.yaml.gotmpl
@@ -36,7 +36,7 @@ spec:
           key: password
 
   terraformRunner: ghcr.io/jenkins-x/terraform-operator-gcp
-  terraformVersion: 3.2.171
+  terraformVersion: 3.2.170
 
   terraformModule:
     address: https://github.com/jenkins-x/learn-terraform-provision-gke-cluster

--- a/.lighthouse/jenkins-x/bdd/terraform-multi-dev.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-multi-dev.yaml.gotmpl
@@ -21,7 +21,7 @@ spec:
 {{- end }}
 
   terraformRunner: ghcr.io/jenkins-x/terraform-operator-gcp
-  terraformVersion: 3.2.171
+  terraformVersion: 3.2.170
 
   terraformModule:
     address: https://github.com/jx3-gitops-repositories/jx3-terraform-gke

--- a/.lighthouse/jenkins-x/bdd/terraform-multi-prod.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-multi-prod.yaml.gotmpl
@@ -21,7 +21,7 @@ spec:
 {{- end }}
 
   terraformRunner: ghcr.io/jenkins-x/terraform-operator-gcp
-  terraformVersion: 3.2.171
+  terraformVersion: 3.2.170
 
   terraformModule:
     address: https://github.com/jx3-gitops-repositories/jx3-terraform-gke

--- a/.lighthouse/jenkins-x/bdd/terraform-tls.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-tls.yaml.gotmpl
@@ -29,7 +29,7 @@ spec:
           key: password
 
   terraformRunner: ghcr.io/jenkins-x/terraform-operator-gcp
-  terraformVersion: 3.2.171
+  terraformVersion: 3.2.170
 
   terraformModule:
     address: https://github.com/jenkins-x-bdd/infra-{{ .Env.TF_VAR_cluster_name }}-dev

--- a/.lighthouse/jenkins-x/bdd/terraform.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform.yaml.gotmpl
@@ -29,7 +29,7 @@ spec:
           key: password
 
   terraformRunner: ghcr.io/jenkins-x/terraform-operator-gcp
-  terraformVersion: 3.2.171
+  terraformVersion: 3.2.170
 
   terraformModule:
     address: https://github.com/jenkins-x-bdd/infra-{{ .Env.TF_VAR_cluster_name }}-dev

--- a/.lighthouse/jenkins-x/pullrequest-bbc.yaml
+++ b/.lighthouse/jenkins-x/pullrequest-bbc.yaml
@@ -19,7 +19,7 @@ spec:
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
-        - image: ghcr.io/jenkins-x/jx:3.2.171
+        - image: ghcr.io/jenkins-x/jx:3.2.170
           name: jx-variables
           resources: {}
           script: |
@@ -31,7 +31,7 @@ spec:
               secretKeyRef:
                 key: password
                 name: bdd-git-bbc
-          image: ghcr.io/jenkins-x/jx:3.2.171
+          image: ghcr.io/jenkins-x/jx:3.2.170
           name: runci
           resources: {}
           script: |

--- a/.lighthouse/jenkins-x/pullrequest-bbs.yaml
+++ b/.lighthouse/jenkins-x/pullrequest-bbs.yaml
@@ -19,7 +19,7 @@ spec:
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
-        - image: ghcr.io/jenkins-x/jx:3.2.171
+        - image: ghcr.io/jenkins-x/jx:3.2.170
           name: jx-variables
           resources: {}
           script: |
@@ -31,7 +31,7 @@ spec:
               secretKeyRef:
                 key: password
                 name: bdd-git-bbs
-          image: ghcr.io/jenkins-x/jx:3.2.171
+          image: ghcr.io/jenkins-x/jx:3.2.170
           name: runci
           resources: {}
           script: |

--- a/.lighthouse/jenkins-x/pullrequest-eks.yaml
+++ b/.lighthouse/jenkins-x/pullrequest-eks.yaml
@@ -19,7 +19,7 @@ spec:
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
-        - image: ghcr.io/jenkins-x/jx:3.2.171
+        - image: ghcr.io/jenkins-x/jx:3.2.170
           name: jx-variables
           resources: {}
           script: |
@@ -31,7 +31,7 @@ spec:
               secretKeyRef:
                 key: password
                 name: bdd-git
-          image: ghcr.io/jenkins-x/jx:3.2.171
+          image: ghcr.io/jenkins-x/jx:3.2.170
           name: runci
           resources: {}
           script: |

--- a/.lighthouse/jenkins-x/pullrequest-ghe.yaml
+++ b/.lighthouse/jenkins-x/pullrequest-ghe.yaml
@@ -20,7 +20,7 @@ spec:
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
-        - image: ghcr.io/jenkins-x/jx:3.2.171
+        - image: ghcr.io/jenkins-x/jx:3.2.170
           name: jx-variables
           resources: {}
           script: |
@@ -32,7 +32,7 @@ spec:
               secretKeyRef:
                 key: password
                 name: bdd-pipeline-token-github-ghe
-          image: ghcr.io/jenkins-x/jx:3.2.171
+          image: ghcr.io/jenkins-x/jx:3.2.170
           name: runci
           resources: {}
           script: |

--- a/.lighthouse/jenkins-x/pullrequest-gitea.yaml
+++ b/.lighthouse/jenkins-x/pullrequest-gitea.yaml
@@ -19,7 +19,7 @@ spec:
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
-        - image: ghcr.io/jenkins-x/jx:3.2.171
+        - image: ghcr.io/jenkins-x/jx:3.2.170
           name: jx-variables
           resources: {}
           script: |
@@ -31,7 +31,7 @@ spec:
               secretKeyRef:
                 key: password
                 name: bdd-git-gitlab
-          image: ghcr.io/jenkins-x/jx:3.2.171
+          image: ghcr.io/jenkins-x/jx:3.2.170
           name: runci
           resources: {}
           script: |

--- a/.lighthouse/jenkins-x/pullrequest-gitlab.yaml
+++ b/.lighthouse/jenkins-x/pullrequest-gitlab.yaml
@@ -19,7 +19,7 @@ spec:
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
-        - image: ghcr.io/jenkins-x/jx:3.2.171
+        - image: ghcr.io/jenkins-x/jx:3.2.170
           name: jx-variables
           resources: {}
           script: |
@@ -31,7 +31,7 @@ spec:
               secretKeyRef:
                 key: password
                 name: bdd-git-gitlab
-          image: ghcr.io/jenkins-x/jx:3.2.171
+          image: ghcr.io/jenkins-x/jx:3.2.170
           name: runci
           resources: {}
           script: |

--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -19,7 +19,7 @@ spec:
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
-        - image: ghcr.io/jenkins-x/jx:3.2.171
+        - image: ghcr.io/jenkins-x/jx:3.2.170
           name: jx-variables
           resources: {}
           script: |
@@ -31,7 +31,7 @@ spec:
               secretKeyRef:
                 key: password
                 name: bdd-git
-          image: ghcr.io/jenkins-x/jx:3.2.171
+          image: ghcr.io/jenkins-x/jx:3.2.170
           name: runci
           resources: {}
           script: |

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -48,7 +48,7 @@ spec:
             ./.lighthouse/jenkins-x/release/promote-jx-website.sh
         - name: changelog
           resources: {}
-        - image: ghcr.io/jenkins-x/jx:3.2.171
+        - image: ghcr.io/jenkins-x/jx:3.2.170
           name: promote-vs
           resources: {}
           script: |

--- a/git-operator/job-azurekeyvault.yaml
+++ b/git-operator/job-azurekeyvault.yaml
@@ -28,7 +28,7 @@ spec:
         - secretRef:
             name: jx-boot-job-env-vars
             optional: true
-        image: ghcr.io/jenkins-x/jx-boot:3.2.171
+        image: ghcr.io/jenkins-x/jx-boot:3.2.170
         name: git-clone
         volumeMounts:
         - mountPath: /workspace
@@ -46,7 +46,7 @@ spec:
         - secretRef:
             name: jx-boot-job-env-vars
             optional: true
-        image: ghcr.io/jenkins-x/jx-boot:3.2.171
+        image: ghcr.io/jenkins-x/jx-boot:3.2.170
         imagePullPolicy: Always
         name: job
         volumeMounts:

--- a/git-operator/job-gsm.yaml
+++ b/git-operator/job-gsm.yaml
@@ -28,7 +28,7 @@ spec:
         - secretRef:
             name: jx-boot-job-env-vars
             optional: true
-        image: ghcr.io/jenkins-x/jx-boot:3.2.171
+        image: ghcr.io/jenkins-x/jx-boot:3.2.170
         name: git-clone
         volumeMounts:
         - mountPath: /workspace
@@ -46,7 +46,7 @@ spec:
         - secretRef:
             name: jx-boot-job-env-vars
             optional: true
-        image: ghcr.io/jenkins-x/jx-boot:3.2.171
+        image: ghcr.io/jenkins-x/jx-boot:3.2.170
         imagePullPolicy: Always
         name: job
         volumeMounts:

--- a/git-operator/job-vault.yaml
+++ b/git-operator/job-vault.yaml
@@ -28,7 +28,7 @@ spec:
         - secretRef:
             name: jx-boot-job-env-vars
             optional: true
-        image: ghcr.io/jenkins-x/jx-boot:3.2.171
+        image: ghcr.io/jenkins-x/jx-boot:3.2.170
         name: git-clone
         volumeMounts:
         - mountPath: /workspace
@@ -46,7 +46,7 @@ spec:
         - secretRef:
             name: jx-boot-job-env-vars
             optional: true
-        image: ghcr.io/jenkins-x/jx-boot:3.2.171
+        image: ghcr.io/jenkins-x/jx-boot:3.2.170
         imagePullPolicy: Always
         name: job
         volumeMounts:

--- a/git-operator/job.yaml
+++ b/git-operator/job.yaml
@@ -28,7 +28,7 @@ spec:
         - secretRef:
             name: jx-boot-job-env-vars
             optional: true
-        image: ghcr.io/jenkins-x/jx-boot:3.2.171
+        image: ghcr.io/jenkins-x/jx-boot:3.2.170
         name: git-clone
         volumeMounts:
         - mountPath: /workspace
@@ -46,7 +46,7 @@ spec:
         - secretRef:
             name: jx-boot-job-env-vars
             optional: true
-        image: ghcr.io/jenkins-x/jx-boot:3.2.171
+        image: ghcr.io/jenkins-x/jx-boot:3.2.170
         imagePullPolicy: Always
         name: job
         volumeMounts:

--- a/git/github.com/jenkins-x/jx3-pipeline-catalog.yml
+++ b/git/github.com/jenkins-x/jx3-pipeline-catalog.yml
@@ -1,6 +1,5 @@
 gitUrl: https://github.com/jenkins-x/jx3-pipeline-catalog.git
-version: 974b52c387d1fabee626da3b78536faf4c7848e9
-
+version: 2c8c0e1cee998018bc633b99996fe086cea81d89
 
 
 

--- a/packages/jx.yml
+++ b/packages/jx.yml
@@ -1,4 +1,4 @@
-version: 3.2.171
+version: 3.2.170
 upperLimit: 4.0.0
 gitUrl: https://github.com/jenkins-x/jx.git
 url: https://jenkins-x.io


### PR DESCRIPTION
Reverts jenkins-x/jx3-versions#2692

looks like the original PR auto merged without running BDD, there are subsequent test failures with duplicate build controller charts in the jx helmfile