### PR TITLE
fix: use correct jx image

### DIFF
--- a/charts/jxgh/jxboot-helmfile-resources/values.yaml.gotmpl
+++ b/charts/jxgh/jxboot-helmfile-resources/values.yaml.gotmpl
@@ -1,5 +1,5 @@
 versions:
-  jxl: 0.0.130
+  jx: {{ readFile "../../../packages/jx.yml" | fromYaml | get "version" | quote }}
 
 sourceRepositoriesEnvKey: true
 


### PR DESCRIPTION
so we align the jx-boot image with the current jx version in the CronJobs for GC'ing resources