### PR TITLE
fix: use central as default mirror

### DIFF
--- a/charts/jxgh/jxboot-helmfile-resources/secret-schema.yaml
+++ b/charts/jxgh/jxboot-helmfile-resources/secret-schema.yaml
@@ -69,7 +69,7 @@ spec:
                 <mirror>
                     <id>nexus</id>
                     <name>nexus mirror</name>
-                    <mirrorOf>external:*</mirrorOf>
+                    <mirrorOf>central</mirrorOf>
                     <url>http://nexus/repository/maven-group/</url>
                 </mirror>
               </mirrors>


### PR DESCRIPTION
fixes https://github.com/jenkins-x/jx3-versions/issues/2768