### PR TITLE
refactor: upgrade external secrets to 8.3.0

### DIFF
--- a/charts/external-secrets/kubernetes-external-secrets/defaults.yaml
+++ b/charts/external-secrets/kubernetes-external-secrets/defaults.yaml
@@ -1,3 +1,3 @@
 gitUrl: https://external-secrets.github.io/kubernetes-external-secrets
 namespace: secret-infra
-version: 6.3.0
+version: 8.3.0


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

Fixes a bunch of CVEs: https://github.com/external-secrets/kubernetes-external-secrets/releases/tag/8.2.1, probably best to upgrade to the latest version (8.3.0)