### PR TITLE
fix: Invalid m2 settings with custom repo

### DIFF
--- a/charts/jxgh/jxboot-helmfile-resources/secret-schema.yaml
+++ b/charts/jxgh/jxboot-helmfile-resources/secret-schema.yaml
@@ -152,9 +152,9 @@ spec:
                       <altReleaseDeploymentRepository>local-nexus::default::http://nexus/repository/maven-releases/</altReleaseDeploymentRepository>
                       <altSnapshotDeploymentRepository>local-nexus::default::http://nexus/repository/maven-snapshots/</altSnapshotDeploymentRepository>
         {{- else }}
-                      <altDeploymentRepository>local-nexus::{{ .Requirements.repository }}::{{ .Requirements.repositories.maven.releaseUrl }}</altDeploymentRepository>
-                      <altReleaseDeploymentRepository>local-nexus::{{ .Requirements.repository }}::{{ .Requirements.repositories.maven.releaseUrl }}</altReleaseDeploymentRepository>
-                      <altSnapshotDeploymentRepository>local-nexus::{{ .Requirements.repository }}::{{ .Requirements.repositories.maven.snapshotUrl | default .Requirements.repositories.maven.releaseUrl }}</altSnapshotDeploymentRepository>
+                      <altDeploymentRepository>{{ .Requirements.repository }}::default::{{ .Requirements.repositories.maven.releaseUrl }}</altDeploymentRepository>
+                      <altReleaseDeploymentRepository>{{ .Requirements.repository }}::default::{{ .Requirements.repositories.maven.releaseUrl }}</altReleaseDeploymentRepository>
+                      <altSnapshotDeploymentRepository>{{ .Requirements.repository }}::default::{{ .Requirements.repositories.maven.snapshotUrl | default .Requirements.repositories.maven.releaseUrl }}</altSnapshotDeploymentRepository>
         {{- end }}
                     </properties>
 


### PR DESCRIPTION
The format was incorrect at the edited location. The only options after the first `::` are `default` and `legacy`.