### PR TITLE
fix: Upgrade cert-manager to 1.2.0

### DIFF
--- a/charts/jetstack/cert-manager/defaults.yaml
+++ b/charts/jetstack/cert-manager/defaults.yaml
@@ -1,3 +1,3 @@
 gitUrl: https://github.com/jetstack/cert-manager
 namespace: cert-manager
-version: 1.7.1
+version: 1.2.0

--- a/charts/jetstack/cert-manager/defaults.yaml
+++ b/charts/jetstack/cert-manager/defaults.yaml
@@ -1,3 +1,3 @@
 gitUrl: https://github.com/jetstack/cert-manager
 namespace: cert-manager
-version: 1.6.2
+version: 1.7.1

--- a/charts/jetstack/cert-manager/defaults.yaml
+++ b/charts/jetstack/cert-manager/defaults.yaml
@@ -1,3 +1,3 @@
 gitUrl: https://github.com/jetstack/cert-manager
 namespace: cert-manager
-version: 1.6.1
+version: 1.6.2

--- a/charts/jetstack/cert-manager/defaults.yaml
+++ b/charts/jetstack/cert-manager/defaults.yaml
@@ -1,3 +1,3 @@
 gitUrl: https://github.com/jetstack/cert-manager
 namespace: cert-manager
-version: 1.1.0
+version: 1.6.0

--- a/charts/jetstack/cert-manager/defaults.yaml
+++ b/charts/jetstack/cert-manager/defaults.yaml
@@ -1,3 +1,3 @@
 gitUrl: https://github.com/jetstack/cert-manager
 namespace: cert-manager
-version: 1.6.0
+version: 1.6.1


### PR DESCRIPTION
Upgrade notes https://cert-manager.io/docs/installation/upgrading/upgrading-1.1-1.2/