### PR TITLE
fix: change acr helper program name to match kaniko

### DIFF
--- a/charts/jxgh/jxboot-helmfile-resources/secret-schema.yaml
+++ b/charts/jxgh/jxboot-helmfile-resources/secret-schema.yaml
@@ -263,7 +263,7 @@ spec:
 
         {{- if and (hasKey .Requirements "cluster") (hasKey .Requirements.cluster "registry") (not (eq .Requirements.cluster.registry (secret "jx.container-registry-auth" "url"))) }}
           "credHelpers": {
-            "{{ .Requirements.cluster.registry }}": "acr-env"
+            "{{ .Requirements.cluster.registry }}": "acr"
           },
         {{- end }}
 


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

Basically kaniko wants acr, and we have `acr-env`.

https://kubernetes.slack.com/archives/C9MBGQJRH/p1640752548310300?thread_ts=1640046751.238900&cid=C9MBGQJRH