### PR TITLE
fix: upgrade ingress-nginx

### DIFF
--- a/charts/ingress-nginx/ingress-nginx/defaults.yaml
+++ b/charts/ingress-nginx/ingress-nginx/defaults.yaml
@@ -1,4 +1,4 @@
 component: ingress-nginx
 gitUrl: https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx
 namespace: nginx
-version: 3.12.0
+version: 4.0.17


### PR DESCRIPTION
This adds compatibility with Kubernetes 1.22, where v1beta1 APIs have been removed.