### PR TITLE
fix: Make sure that namespaces will not be purged

### DIFF
--- a/src/Makefile.mk
+++ b/src/Makefile.mk
@@ -288,7 +288,7 @@ kubectl-apply:
 
 # NOTE be very careful about these 2 labels as getting them wrong can remove stuff in you cluster!
 	kubectl apply $(KUBECTL_APPLY_FLAGS) --prune -l=gitops.jenkins-x.io/pipeline=customresourcedefinitions -R -f $(OUTPUT_DIR)/customresourcedefinitions
-	kubectl apply $(KUBECTL_APPLY_FLAGS) --prune -l=gitops.jenkins-x.io/pipeline=cluster                   -R -f $(OUTPUT_DIR)/cluster
+	kubectl apply $(KUBECTL_APPLY_FLAGS) -l=gitops.jenkins-x.io/pipeline=cluster                           -R -f $(OUTPUT_DIR)/cluster
 	kubectl apply $(KUBECTL_APPLY_FLAGS) --prune -l=gitops.jenkins-x.io/pipeline=namespaces                -R -f $(OUTPUT_DIR)/namespaces
 
 # lets apply any infrastructure specific labels or annotations to enable IAM roles on ServiceAccounts etc


### PR DESCRIPTION
There was an issue reported on Slack: https://kubernetes.slack.com/archives/C9MBGQJRH/p1647955769010979

Generally I think that resources such as **namespaces** should be excluded from purging.
I upgraded my two clusters and was not able to reproduce the issue.

Possible Scenario
------------------------

We fixed an issue that some resources were not created because of bug in `jx gitops` (see PR: https://github.com/jenkins-x-plugins/jx-gitops/pull/835), so a new resources started appearing - for me a `jx-git-operator` namespace was created after cluster upgrade AND IT WAS LOOKING FINE, nothing was deleted.

```
 31 files changed, 4347 insertions(+), 4484 deletions(-)
 create mode 100644 config-root/cluster/namespaces/jx-git-operator.yaml
```

But what if somebody had different labels applied on `jx-git-operator-namespace`, maybe older version of Jenkins X? Then freshly created `namespace` maybe was different from that applied on a cluster and the old one was pruned, so the bootjob stopped and new one had no time to apply?

Resolution
--------------

Do not prune namespaces, as it is really dangerous, namespaces could be shared with other applications and should not be pruned cluster-wide.

Compromise: We do not prune anymore resources that are cluster scoped (role bindings, namespaces)