### PR TITLE
chore: manually bump charts other than tkn

### DIFF
--- a/charts/jxgh/jx-build-controller/defaults.yaml
+++ b/charts/jxgh/jx-build-controller/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x-plugins/jx-build-controller
-version: 0.3.9
+version: 0.3.11

--- a/charts/jxgh/jx-preview/defaults.yaml
+++ b/charts/jxgh/jx-preview/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jx-preview
-version: 0.0.194
+version: 0.0.195

--- a/charts/jxgh/jxboot-helmfile-resources/defaults.yaml
+++ b/charts/jxgh/jxboot-helmfile-resources/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x-charts/jxboot-helmfile-resources
-version: 1.1.38
+version: 1.1.47


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

Tekton upgrade requires a PR from pipeline catalog, which will be merged this weekend, but we can bump other charts in the meantime.