### PR TITLE
fix: update certmanager and external secrets periodically

### DIFF
--- a/.github/workflows/update-charts/updatebot.yaml
+++ b/.github/workflows/update-charts/updatebot.yaml
@@ -12,3 +12,7 @@ spec:
               - jenkins-x/*
               - jx3/*
               - jxgh/*
+              # Cert manager
+              - jetstack/*
+              # External secrets
+              - external-secrets/*


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

Since we are already on 1.7.X version of cert manager, we can update start auto updating cert manager charts. Same for external secrets chart.