### PR TITLE
chore: Upgrade external-dns

### DIFF
--- a/charts/bitnami/external-dns/defaults.yaml
+++ b/charts/bitnami/external-dns/defaults.yaml
@@ -1,1 +1,1 @@
-version: 6.0.2
+version: 6.5.2

--- a/charts/bitnami/external-dns/defaults.yaml
+++ b/charts/bitnami/external-dns/defaults.yaml
@@ -1,1 +1,1 @@
-version: 6.5.2
+version: 6.5.1


### PR DESCRIPTION
6.0.2 can no longer be do downloaded
Trying latest version