### PR TITLE
Update values.yaml.gotmpl

### DIFF
--- a/charts/argocd/argocd/values.yaml.gotmpl
+++ b/charts/argocd/argocd/values.yaml.gotmpl
@@ -1,18 +1,24 @@
 server:
-{{- if not .Values.jxRequirements.ingress.tls.enabled }}
   extraArgs:
   - --insecure
-{{- end }}
-  ingressGrpc:
-    enabled: true
-    annotations:
-      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-    hosts:
-    - argogrpc{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
   ingress:
-    enabled: true
-    annotations:
-      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-      nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    hosts:
-    - argo{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }} 
+      enabled: true
+      annotations:
+            cert-manager.io/cluster-issuer: letsencrypt-prod
+            kubernetes.io/ingress.class: "nginx"
+            nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+            nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+      hosts:
+        - argo{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }} 
+      tls:      
+        - secretName: argocd-server-tls
+          hosts:
+            - argo{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }} 
+  ingressGrpc:
+      enabled: true
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+        nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+      hosts: 
+      - argogrpc{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+      https: true


### PR DESCRIPTION
The version stream does not work out of the box there is a problem with the logic
If you enable tls the secure server should be disabled and the backend (argo-server) port should be HTTP because the ingress takes care of the SSL offloading - this should be out of the box config.
If tls is disabled then we don't need the tls config but its not recommended