### PR TITLE
fix: Don't download context

### DIFF
--- a/.lighthouse/jenkins-x/bdd/remote/ci.sh
+++ b/.lighthouse/jenkins-x/bdd/remote/ci.sh
@@ -104,7 +104,7 @@ gcloud container clusters get-credentials $STAGING_CLUSTER_NAME --zone $ZONE --p
 
 
 jx ns jx-staging
-jx ctx -b
+jx ns -b
 
 jxl boot create -b --env staging -b --version-stream-ref=$PULL_PULL_SHA --env-git-owner=$GH_OWNER --project=$PROJECT_ID --cluster=$CLUSTER_NAME --zone=$ZONE --git-url=$STAGING_GIT_URL
 
@@ -116,7 +116,7 @@ jxl boot run -b --job
 echo "SWITCH: to dev cluster: $STAGING_CLUSTER_NAME to start BDD tests"
 gcloud container clusters get-credentials $DEV_CLUSTER_NAME --zone $ZONE --project $PROJECT_ID
 jx ns jx
-jx ctx -b
+jx ns -b
 
 # for some reason we need to use the full name once for the second command to work!
 kubectl get environments

--- a/.lighthouse/jenkins-x/bdd/terraform-bbc.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-bbc.yaml.gotmpl
@@ -60,7 +60,7 @@ spec:
     $(terraform output -raw connect)
 
     echo "now connected to cluster:"
-    jx ctx -b
+    jx ns -b
 
     echo "using jx version: $JX_VERSION"
 

--- a/.lighthouse/jenkins-x/bdd/terraform-bbs.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-bbs.yaml.gotmpl
@@ -69,7 +69,7 @@ spec:
     $(terraform output -raw connect)
 
     echo "now connected to cluster:"
-    jx ctx -b
+    jx ns -b
 
     echo "using jx version: $JX_VERSION"
 

--- a/.lighthouse/jenkins-x/bdd/terraform-eks.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-eks.yaml.gotmpl
@@ -74,7 +74,7 @@ spec:
     kubectl get ns
 
     echo "now connected to cluster:"
-    jx ctx -b
+    jx ns -b
 
     echo "using jx version: $JX_VERSION"
 

--- a/.lighthouse/jenkins-x/bdd/terraform-ghe.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-ghe.yaml.gotmpl
@@ -69,7 +69,7 @@ spec:
     $(terraform output -raw connect)
 
     echo "now connected to cluster:"
-    jx ctx -b
+    jx ns -b
 
     echo "using jx version: $JX_VERSION"
 

--- a/.lighthouse/jenkins-x/bdd/terraform-gitea.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-gitea.yaml.gotmpl
@@ -56,7 +56,7 @@ spec:
     $(terraform output -raw connect)
 
     echo "now connected to cluster:"
-    jx ctx -b
+    jx ns -b
 
     echo "using jx version: $JX_VERSION"
 

--- a/.lighthouse/jenkins-x/bdd/terraform-gitlab.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-gitlab.yaml.gotmpl
@@ -69,7 +69,7 @@ spec:
     $(terraform output -raw connect)
 
     echo "now connected to cluster:"
-    jx ctx -b
+    jx ns -b
 
     echo "using jx version: $JX_VERSION"
 

--- a/.lighthouse/jenkins-x/bdd/terraform-kube.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-kube.yaml.gotmpl
@@ -69,7 +69,7 @@ spec:
     $(terraform output -raw connect)
 
     echo "now connected to cluster:"
-    jx ctx -b
+    jx ns -b
 
     echo "using jx version: $JX_VERSION"
 

--- a/.lighthouse/jenkins-x/bdd/terraform-kubevault.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-kubevault.yaml.gotmpl
@@ -69,7 +69,7 @@ spec:
     $(terraform output -raw connect)
 
     echo "now connected to cluster:"
-    jx ctx -b
+    jx ns -b
 
     echo "using jx version: $JX_VERSION"
 

--- a/.lighthouse/jenkins-x/bdd/terraform-multi-dev.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-multi-dev.yaml.gotmpl
@@ -61,7 +61,7 @@ spec:
     $(terraform output -raw connect)
 
     echo "now connected to cluster:"
-    jx ctx -b
+    jx ns -b
 
     echo "using jx version: $JX_VERSION"
 

--- a/.lighthouse/jenkins-x/bdd/terraform-multi-prod.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-multi-prod.yaml.gotmpl
@@ -61,7 +61,7 @@ spec:
     $(terraform output -raw connect)
 
     echo "now connected to cluster:"
-    jx ctx -b
+    jx ns -b
 
     echo "using jx version: $JX_VERSION"
 

--- a/.lighthouse/jenkins-x/bdd/terraform-tls.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform-tls.yaml.gotmpl
@@ -69,7 +69,7 @@ spec:
     $(terraform output -raw connect)
 
     echo "now connected to cluster:"
-    jx ctx -b
+    jx ns -b
 
     # verify we have the correct context
     jx verify ctx -c "gke_${TF_VAR_gcp_project}_us-central1-a_${TF_VAR_cluster_name}"

--- a/.lighthouse/jenkins-x/bdd/terraform.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform.yaml.gotmpl
@@ -73,7 +73,7 @@ spec:
     $(terraform output -raw connect)
 
     echo "now connected to cluster:"
-    jx ctx -b
+    jx ns -b
 
     echo "using jx version: $JX_VERSION"
 


### PR DESCRIPTION
This is to prevent errors in the builds like

```
+ jx ctx -b
ERROR: failed to load plugin jx-context: can't find latest version of plugin: {"message":"API rate limit exceeded for 35.225.186.19. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"[https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}](https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting)
```

`jx ns -b` and `jx ctx -b` gives the same output.