### PR TITLE
chore: disable tekton chart auto upgrade

### DIFF
--- a/.github/workflows/update-charts/updatebot.yaml
+++ b/.github/workflows/update-charts/updatebot.yaml
@@ -8,7 +8,7 @@ spec:
         - versionStream:
             kind: charts
             include:
-              - cdf/*
+              # - cdf/*
               - jenkins-x/*
               - jx3/*
               - jxgh/*


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

Tekton upgrades need more testing, and hence we should disable the auto upgrades for now (re-enable it after we expand our tests to include testing on existing clusters)