### PR TITLE
fix: only apply CRDs if they exist

### DIFF
--- a/src/Makefile.mk
+++ b/src/Makefile.mk
@@ -288,7 +288,9 @@ kubectl-apply:
 	@echo "using kubectl to apply resources"
 
 # NOTE be very careful about these 2 labels as getting them wrong can remove stuff in you cluster!
-	kubectl apply $(KUBECTL_APPLY_FLAGS) --prune -l=gitops.jenkins-x.io/pipeline=customresourcedefinitions -R -f $(OUTPUT_DIR)/customresourcedefinitions
+	if [ -d $(OUTPUT_DIR)/customresourcedefinitions ]; then \
+	  kubectl apply $(KUBECTL_APPLY_FLAGS) --prune -l=gitops.jenkins-x.io/pipeline=customresourcedefinitions -R -f $(OUTPUT_DIR)/customresourcedefinitions; \
+	fi
 	kubectl apply $(KUBECTL_APPLY_FLAGS) --prune -l=gitops.jenkins-x.io/pipeline=cluster                   -R -f $(OUTPUT_DIR)/cluster
 	kubectl apply $(KUBECTL_APPLY_FLAGS) --prune -l=gitops.jenkins-x.io/pipeline=namespaces                -R -f $(OUTPUT_DIR)/namespaces
 


### PR DESCRIPTION
When deploying a separate staging/production environment without kuberhealthy, there are no CRDs and the boot job fails. See https://kubernetes.slack.com/archives/C9MBGQJRH/p1659537849699819 