### PR TITLE
fix: use HELMFILE_TEMPLATE_FLAGS in 'helmfile template'

### DIFF
--- a/src/Makefile.mk
+++ b/src/Makefile.mk
@@ -133,7 +133,7 @@ fetch: init $(COPY_SOURCE) $(REPOSITORY_RESOLVE)
 	jx gitops image -s .jx/git-operator
 
 # generate the yaml from the charts in helmfile.yaml and moves them to the right directory tree (cluster or namespaces/foo)
-	helmfile --file helmfile.yaml template --validate --include-crds --output-dir-template /tmp/generate/{{.Release.Namespace}}/{{.Release.Name}}
+	helmfile --file helmfile.yaml template $(HELMFILE_TEMPLATE_FLAGS) --validate --include-crds --output-dir-template /tmp/generate/{{.Release.Namespace}}/{{.Release.Name}}
 
 	jx gitops split --dir /tmp/generate
 	jx gitops rename --dir /tmp/generate


### PR DESCRIPTION
the contents of https://github.com/jenkins-x/jx3-versions/blob/62fc4d6bff12a1c4bacfc87f6291d102fda5ef35/src/Makefile.mk#L62-L69 leads users to believe that they are able to configure additional helmfile template flags via the `HELMFILE_TEMPLATE_FLAGS` env var. this feature seems to have been lost in translation in [this PR](https://github.com/jenkins-x/jx3-versions/pull/1823). [according to slack records](https://kubernetes.slack.com/archives/C9MBGQJRH/p1616755962449000?thread_ts=1616755638.448000&cid=C9MBGQJRH), there doesn't seem to be any explicit reason this was disabled

i personally have a use case of adding the flag `--skip-tests` to disable some noisy helm chart test pods rendered by `helmfile template`. ref https://github.com/jenkins-x-plugins/jx-gitops/pull/885