### PR TITLE
chore: upgrade jx-build-controller to 0.4.3

### DIFF
--- a/charts/jxgh/jx-build-controller/defaults.yaml
+++ b/charts/jxgh/jx-build-controller/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x-plugins/jx-build-controller
-version: 0.4.0
+version: 0.4.3


### PR DESCRIPTION
https://github.com/jenkins-x/jx3-versions/pull/3372 -> chart upgrade has been failing for some time, trying to isolate which chart is breaking e2e tests.