### PR TITLE
chore: manual bump of charts

### DIFF
--- a/charts/jxgh/jx-preview/defaults.yaml
+++ b/charts/jxgh/jx-preview/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jx-preview
-version: 0.0.224
+version: 0.0.225

--- a/charts/jxgh/jx-slack/defaults.yaml
+++ b/charts/jxgh/jx-slack/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x-plugins/jx-slack
-version: 0.2.0
+version: 0.2.1

--- a/charts/jxgh/jx-ui/defaults.yaml
+++ b/charts/jxgh/jx-ui/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jx-ui
-version: 0.0.12
+version: 0.0.17

--- a/charts/jxgh/vault-instance/defaults.yaml
+++ b/charts/jxgh/vault-instance/defaults.yaml
@@ -1,3 +1,3 @@
 gitUrl: https://github.com/jenkins-x-charts/vault-instance
 namespace: secret-infra
-version: 1.0.26
+version: 1.0.27


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

Charts bumped:
- jx-preview
- jx-slack
- jx-ui
- vault-instance

The auto upgrades are blocked because tests fail, trying to isolate the issue