### PR TITLE
refactor: remove creating a new version on every commit to main branch

### DIFF
--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -23,8 +23,6 @@ spec:
             - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
               name: ""
               resources: {}
-            - name: next-version
-              resources: {}
             - name: jx-variables
               resources: {}
             - image: ghcr.io/jenkins-x/jx-scm:0.1.5

--- a/.lighthouse/jenkins-x/release/promote-vs.sh
+++ b/.lighthouse/jenkins-x/release/promote-vs.sh
@@ -11,7 +11,7 @@ declare -a repos=(
   # GKE
   "jx3-gke-vault" "jx3-gke-gsm" "jx3-gke-gsm-gitea" "jx3-gke-gcloud-vault"
   # EKS
-  "jx3-eks-asm" "jx3-eks-vault"  
+  "jx3-eks-asm" "jx3-eks-vault"
   # Azure
   "jx3-azure-vault" "jx3-azure-akv"
   # OpenShift
@@ -48,15 +48,13 @@ function upgradeClusterRepo {
   git push || true
 }
 
-for r in "${repos[@]}"
-do
+for r in "${repos[@]}"; do
   upgradeClusterRepo $r environment
 done
 
 upgradeClusterRepo jx3-kubernetes-production environment-remote
 
-for r in "${tfrepos[@]}"
-do
+for r in "${tfrepos[@]}"; do
   echo "upgrading repository https://github.com/jx3-gitops-repositories/$r"
   cd $TMPDIR
   git clone https://github.com/jx3-gitops-repositories/$r.git
@@ -67,11 +65,11 @@ do
 done
 
 # lets upgarde our own infra automatically
-LOCAL_BRANCH_NAME="jx-vs_$VERSION"
+LOCAL_BRANCH_NAME="jx-vs_$(date +%s)"
 cd $TMPDIR
 git clone https://github.com/jenkins-x/jx3-oss-cluster.git
 cd "jx3-oss-cluster"
 git checkout -b $LOCAL_BRANCH_NAME
-jx gitops upgrade --commit-message "chore: version stream upgrade $VERSION"
+jx gitops upgrade --commit-message "chore: version stream upgrade"
 git push origin $LOCAL_BRANCH_NAME
-jx create pullrequest -t "chore: version stream upgrade $VERSION" -l updatebot
+jx create pullrequest -t "chore: version stream upgrade" -l updatebot

--- a/.lighthouse/jenkins-x/release/update-jx-website.sh
+++ b/.lighthouse/jenkins-x/release/update-jx-website.sh
@@ -7,7 +7,7 @@ set -o pipefail
 if $(cat ${IS_JX_PRERELEASE})
 then
   JX_VERSION=$(sed "s:^.*jenkins-x\/jx.*\[\([0-9.]*\)\].*$:\1:;t;d" ./dependency-matrix/matrix.md)
-  LOCAL_BRANCH_NAME="jx_cli_$VERSION"
+  LOCAL_BRANCH_NAME="jx-vs_$(date +%s)"
   if [[ $JX_VERSION =~ ^[0-9]*\.[0-9]*\.[0-9]*$ ]]
   then
     echo "updating the CLI reference"


### PR DESCRIPTION
This tag/version is not used much, apart from naming branches. kpt points to a commit sha in main branch.
So for LTS, we can just start tagging manually after we have tested the changes in the release branch

Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>