### PR TITLE
feat: Add ttlSecondsAfterFinished to jobs

### DIFF
--- a/git-operator/job-azurekeyvault.yaml
+++ b/git-operator/job-azurekeyvault.yaml
@@ -8,6 +8,7 @@ spec:
   backoffLimit: 4
   completions: 1
   parallelism: 1
+  ttlSecondsAfterFinished: 86400
   template:
     metadata:
       labels:

--- a/git-operator/job-gsm.yaml
+++ b/git-operator/job-gsm.yaml
@@ -8,6 +8,7 @@ spec:
   backoffLimit: 4
   completions: 1
   parallelism: 1
+  ttlSecondsAfterFinished: 86400
   template:
     metadata:
       labels:

--- a/git-operator/job-vault.yaml
+++ b/git-operator/job-vault.yaml
@@ -8,6 +8,7 @@ spec:
   backoffLimit: 4
   completions: 1
   parallelism: 1
+  ttlSecondsAfterFinished: 86400
   template:
     metadata:
       labels:

--- a/git-operator/job.yaml
+++ b/git-operator/job.yaml
@@ -8,6 +8,7 @@ spec:
   backoffLimit: 4
   completions: 1
   parallelism: 1
+  ttlSecondsAfterFinished: 86400
   template:
     metadata:
       labels:

--- a/src/Makefile.mk
+++ b/src/Makefile.mk
@@ -62,7 +62,7 @@ KUBECTL_APPLY_FLAGS ?= --force
 KPT_LIVE_APPLY_FLAGS ?= --install-resource-group --inventory-policy=adopt --reconcile-timeout=15m
 
 # When using kpt live apply on a development cluster you could set
-#   PR_LINT = kpt-live-apply-dry-run
+#   PR_LINT = kpt-apply-dry-run
 # in the repository Makefile to get a linting of the manifests
 PR_LINT ?=
 


### PR DESCRIPTION
This means that jx-gcjobs isn't needed anymore
This is particularly useful in remote clusters where you otherwise don't need jxboot-helmfile-resources there

While at it I also fix a typo in comment