### PR TITLE
fix: remove failing and unused repository

### DIFF
--- a/charts/repositories.yml
+++ b/charts/repositories.yml
@@ -1,7 +1,4 @@
 repositories:
-- prefix: banzaicloud-stable
-  urls:
-  - https://kubernetes-charts.banzaicloud.com
 - prefix: bitnami
   urls:
   - https://charts.bitnami.com/bitnami


### PR DESCRIPTION
I don't think it hurts to have it here per se, but it can't be used so can as well be removed.

The repo gives
Error: looks like "https://kubernetes-charts.banzaicloud.com" is not a valid chart repository or cannot be reached: Get "https://kubernetes-charts.banzaicloud.com/index.yaml": x509: certificate has expired or is not yet valid: current time 2022-12-19T08:18:17Z is after 2022-12-19T07:42:55Z