### PR TITLE
fix: update-go action

### DIFF
--- a/.github/workflows/update-go.yml
+++ b/.github/workflows/update-go.yml
@@ -15,6 +15,6 @@ jobs:
       - env:
           GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
         name: updatebot
-        uses: ghcr.io/jenkins-x/jx-updatebot:0.0.75
+        uses: docker://ghcr.io/jenkins-x/jx-updatebot:0.4.0
         with:
           args: pr -c .github/workflows/update-go/updatebot.yaml --no-version --git-credentials

--- a/.lighthouse/jenkins-x/bdd/terraform-ci.sh
+++ b/.lighthouse/jenkins-x/bdd/terraform-ci.sh
@@ -92,8 +92,9 @@ export TERRAFORM_INPUT="-input=false"
 export TF_VAR_force_destroy=true
 
 export PROJECT_ID=jenkins-x-bdd-326715
-export CREATED_TIME=$(date '+%y%m%d-%H%M')
-export CLUSTER_NAME="${BRANCH_NAME,,}-$CREATED_TIME-$BDD_NAME"
+export CREATED_TIME=$(date '+%a-%b-%d-%Y-%H-%M-%S')
+export RANDOM=$(tr -dc 'a-z0-9' < /dev/urandom | head -c5)
+export CLUSTER_NAME="${BRANCH_NAME,,}-$BUILD_NUMBER-$RANDOM-$BDD_NAME"
 export ZONE=europe-west1-c
 export LABELS="branch=${BRANCH_NAME,,},cluster=$BDD_NAME,create-time=${CREATED_TIME,,}"
 

--- a/.lighthouse/jenkins-x/bdd/terraform-ci.sh
+++ b/.lighthouse/jenkins-x/bdd/terraform-ci.sh
@@ -92,7 +92,7 @@ export TERRAFORM_INPUT="-input=false"
 export TF_VAR_force_destroy=true
 
 export PROJECT_ID=jenkins-x-bdd-326715
-export CREATED_TIME=$(date '+%Y-%m-%d-%H-%M-%S')
+export CREATED_TIME=$(date '+%y%m%d-%H%M')
 export CLUSTER_NAME="${BRANCH_NAME,,}-$CREATED_TIME-$BDD_NAME"
 export ZONE=europe-west1-c
 export LABELS="branch=${BRANCH_NAME,,},cluster=$BDD_NAME,create-time=${CREATED_TIME,,}"

--- a/.lighthouse/jenkins-x/bdd/terraform-ci.sh
+++ b/.lighthouse/jenkins-x/bdd/terraform-ci.sh
@@ -92,8 +92,8 @@ export TERRAFORM_INPUT="-input=false"
 export TF_VAR_force_destroy=true
 
 export PROJECT_ID=jenkins-x-bdd-326715
-export CREATED_TIME=$(date '+%a-%b-%d-%Ybin/ main.tf values.auto.tfvars terraform.tfstate variables.tf-%H-%M-%S')
-export CLUSTER_NAME="${BRANCH_NAME,,}-$BUILD_NUMBER-$BDD_NAME"
+export CREATED_TIME=$(date '+%Y-%m-%d-%H-%M-%S')
+export CLUSTER_NAME="${BRANCH_NAME,,}-$CREATED_TIME-$BDD_NAME"
 export ZONE=europe-west1-c
 export LABELS="branch=${BRANCH_NAME,,},cluster=$BDD_NAME,create-time=${CREATED_TIME,,}"
 

--- a/.lighthouse/jenkins-x/bdd/terraform.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform.yaml.gotmpl
@@ -1,6 +1,7 @@
 apiVersion: tf.isaaguilar.com/v1alpha1
 kind: Terraform
 spec:
+  persistentVolumeSize: "4Gi"
   env:
   - name: KUBECONFIG
     value: "/tmp/kubecfg"


### PR DESCRIPTION
Mainly to prevent annoying error mail
![.github/workflows/update-go.yml: No jobs were run](https://user-images.githubusercontent.com/3265455/208399461-ed6ff604-a885-449a-b59e-6c4d9b063d94.png)

But maybe it is useful to run....
