### PR TITLE
fix: upgrade external-dns to 6.7.0

### DIFF
--- a/charts/bitnami/external-dns/defaults.yaml
+++ b/charts/bitnami/external-dns/defaults.yaml
@@ -1,1 +1,1 @@
-version: 6.4.5
+version: 6.7.0


### PR DESCRIPTION
the chart for the previous version are unavailable