### PR TITLE
chore: external-dns to 6.12.2

### DIFF
--- a/charts/bitnami/external-dns/defaults.yaml
+++ b/charts/bitnami/external-dns/defaults.yaml
@@ -1,1 +1,1 @@
-version: 6.7.0
+version: 6.12.2


### PR DESCRIPTION
This upgrade contains this fix which affects users https://github.com/kubernetes-sigs/external-dns/pull/2913