### PR TITLE
fix: if anything is changed in jx ns then run without selector

### DIFF
--- a/src/get-selectors-and-clean.sh
+++ b/src/get-selectors-and-clean.sh
@@ -4,14 +4,19 @@ OUTPUT_DIR=$1
 
 SELECTOR=""
 if ! git log -m -1 --name-only --pretty=format: | grep -qv "^helmfiles/"; then
-  for namespace in $(git log -m -1 --name-only --pretty=format: | grep "^helmfiles/" | cut -d "/" -f 2 | sort -u); do
-    SELECTOR="${SELECTOR} --selector namespace=${namespace}"
-    rm -rf ${OUTPUT_DIR}/cluster/namespaces/${namespace}.yaml
-    rm -rf ${OUTPUT_DIR}/cluster/resources/${namespace}
-    rm -rf ${OUTPUT_DIR}/customresourcedefinitions/${namespace}
-    rm -rf ${OUTPUT_DIR}/namespaces/${namespace}
-  done
-  >&2 echo helmfile with selector ${SELECTOR}
+  changedNamespaces=$(git log -m -1 --name-only --pretty=format: | grep "^helmfiles/" | cut -d "/" -f 2 | sort -u)
+    if echo "$changedNamespaces" | grep -q ^jx$; then
+        >&2 echo jx namespace changed, no selectors added
+    else
+      for namespace in ${changedNamespaces}; do
+        SELECTOR="${SELECTOR} --selector namespace=${namespace}"
+        rm -rf ${OUTPUT_DIR}/cluster/namespaces/${namespace}.yaml
+        rm -rf ${OUTPUT_DIR}/cluster/resources/${namespace}
+        rm -rf ${OUTPUT_DIR}/customresourcedefinitions/${namespace}
+        rm -rf ${OUTPUT_DIR}/namespaces/${namespace}
+      done
+      >&2 echo helmfile with selector ${SELECTOR}
+    fi
 fi
 
 if [ -z "${SELECTOR}" ]; then
@@ -21,4 +26,3 @@ if [ -z "${SELECTOR}" ]; then
 fi
 
 echo ${SELECTOR}
-

--- a/src/get-selectors-and-clean.sh
+++ b/src/get-selectors-and-clean.sh
@@ -5,18 +5,18 @@ OUTPUT_DIR=$1
 SELECTOR=""
 if ! git log -m -1 --name-only --pretty=format: | grep -qv "^helmfiles/"; then
   changedNamespaces=$(git log -m -1 --name-only --pretty=format: | grep "^helmfiles/" | cut -d "/" -f 2 | sort -u)
-    if echo "$changedNamespaces" | grep -q ^jx$; then
-        >&2 echo jx namespace changed, no selectors added
-    else
-      for namespace in ${changedNamespaces}; do
-        SELECTOR="${SELECTOR} --selector namespace=${namespace}"
-        rm -rf ${OUTPUT_DIR}/cluster/namespaces/${namespace}.yaml
-        rm -rf ${OUTPUT_DIR}/cluster/resources/${namespace}
-        rm -rf ${OUTPUT_DIR}/customresourcedefinitions/${namespace}
-        rm -rf ${OUTPUT_DIR}/namespaces/${namespace}
-      done
-      >&2 echo helmfile with selector ${SELECTOR}
-    fi
+  if echo "$changedNamespaces" | grep -q ^jx$; then
+    >&2 echo jx namespace changed, no selectors added
+  else
+    for namespace in ${changedNamespaces}; do
+      SELECTOR="${SELECTOR} --selector namespace=${namespace}"
+      rm -rf ${OUTPUT_DIR}/cluster/namespaces/${namespace}.yaml
+      rm -rf ${OUTPUT_DIR}/cluster/resources/${namespace}
+      rm -rf ${OUTPUT_DIR}/customresourcedefinitions/${namespace}
+      rm -rf ${OUTPUT_DIR}/namespaces/${namespace}
+    done
+    >&2 echo helmfile with selector ${SELECTOR}
+  fi
 fi
 
 if [ -z "${SELECTOR}" ]; then


### PR DESCRIPTION
This PR resolves the problems with source repositories being removed if a values file is modified seen in [this issue](https://github.com/jenkins-x/jx3-versions/issues/3491).

The change means that if anything is modified in the jx namespace then no helmfile selectors are added so all namespaces get properly templated.