### PR TITLE
fix: remove todo from ok-to-test message

### DIFF
--- a/schedulers/default.yaml
+++ b/schedulers/default.yaml
@@ -117,6 +117,5 @@ spec:
     ignore_ok_to_test: false
     join_org_url: ""
     only_org_members: false
-    trusted_org: todo
   welcome:
     - message_template: Welcome

--- a/schedulers/environment-review-required.yaml
+++ b/schedulers/environment-review-required.yaml
@@ -101,6 +101,5 @@ spec:
     ignore_ok_to_test: false
     join_org_url: ""
     only_org_members: false
-    trusted_org: todo
   welcome:
     - message_template: Welcome

--- a/schedulers/environment.yaml
+++ b/schedulers/environment.yaml
@@ -118,6 +118,5 @@ spec:
     ignore_ok_to_test: false
     join_org_url: ""
     only_org_members: false
-    trusted_org: todo
   welcome:
     - message_template: Welcome

--- a/schedulers/in-repo.yaml
+++ b/schedulers/in-repo.yaml
@@ -81,6 +81,5 @@ spec:
     ignore_ok_to_test: false
     join_org_url: ""
     only_org_members: false
-    trusted_org: todo
   welcome:
     - message_template: Welcome


### PR DESCRIPTION
In ok-to-test messages like [this](https://github.com/jenkins-x/jx3-versions/pull/3501#issuecomment-1379516844) there are a couple of bogus links to the org **todo**. This fix removes those or replaces with the org of the repo.