### PR TITLE
chore: external-dns to 6.13.1

### DIFF
--- a/charts/bitnami/external-dns/defaults.yaml
+++ b/charts/bitnami/external-dns/defaults.yaml
@@ -1,1 +1,1 @@
-version: 6.12.2
+version: 6.13.1


### PR DESCRIPTION
This upgrade includes a fix for nil pointer errors due to ingresses longer than 63 characters

https://github.com/kubernetes-sigs/external-dns/pull/3294