### PR TITLE
fix: lgtm before approve

### DIFF
--- a/schedulers/default.yaml
+++ b/schedulers/default.yaml
@@ -22,11 +22,11 @@ spec:
     target_url: http://lighthouse{{ .Requirements.ingress.namespaceSubDomain }}{{ .Requirements.ingress.domain }}/merge/status
   plugins:
     entries:
+      - lgtm
       - approve
       - assign
       - help
       - hold
-      - lgtm
       - lifecycle
       - override
       - size

--- a/schedulers/environment-review-required.yaml
+++ b/schedulers/environment-review-required.yaml
@@ -22,12 +22,12 @@ spec:
     target_url: http://lighthouse{{ .Requirements.ingress.namespaceSubDomain }}{{ .Requirements.ingress.domain }}/merge/status
   plugins:
     entries:
+      - lgtm
       - config-updater
       - approve
       - assign
       - help
       - hold
-      - lgtm
       - lifecycle
       - size
       - trigger

--- a/schedulers/environment.yaml
+++ b/schedulers/environment.yaml
@@ -22,12 +22,12 @@ spec:
     target_url: http://lighthouse{{ .Requirements.ingress.namespaceSubDomain }}{{ .Requirements.ingress.domain }}/merge/status
   plugins:
     entries:
+      - lgtm
       - config-updater
       - approve
       - assign
       - help
       - hold
-      - lgtm
       - lifecycle
       - size
       - trigger

--- a/schedulers/in-repo.yaml
+++ b/schedulers/in-repo.yaml
@@ -24,11 +24,11 @@ spec:
   in_repo: true
   plugins:
     entries:
+      - lgtm
       - approve
       - assign
       - help
       - hold
-      - lgtm
       - lifecycle
       - override
       - size

--- a/schedulers/jx-meta-pipeline.yaml
+++ b/schedulers/jx-meta-pipeline.yaml
@@ -22,11 +22,11 @@ spec:
     target_url: http://lighthouse{{ .Requirements.ingress.namespaceSubDomain }}{{ .Requirements.ingress.domain }}/merge/status
   plugins:
     entries:
+      - lgtm
       - approve
       - assign
       - help
       - hold
-      - lgtm
       - lifecycle
       - override
       - size


### PR DESCRIPTION
Since approve might look at the lgtm label it should be executed after lgtm.

Without this fix I just saw this behaviour:

1. I added the comment /lgtm
2. lgtm plugin added the lgtm label
3. another commit was added to the PR
4. approve saw the lgtm label and added the approved label
5. lgtm removed the lgtm label since a change was detected since the /lgtm comment

The behaviour we want is 

1. I add the comment /lgtm
2. lgtm plugin adds the lgtm label
3. approve see the lgtm label and add the approved label
4. another commit was added to the PR
5. lgtm removes the lgtm label since a change was detected since the /lgtm comment
6. approve removes the approved label

I'm not sure changing the order of the plugins gives the desired behaviour
