### PR TITLE
fix: prevent conflicts by not updating docs in PR

### DIFF
--- a/.lighthouse/jenkins-x/bdd/terraform-ci.sh
+++ b/.lighthouse/jenkins-x/bdd/terraform-ci.sh
@@ -93,8 +93,8 @@ export TF_VAR_force_destroy=true
 
 export PROJECT_ID=jenkins-x-bdd-326715
 export CREATED_TIME=$(date '+%a-%b-%d-%Y-%H-%M-%S')
-export RANDOM=$(tr -dc 'a-z0-9' < /dev/urandom | head -c6)
-export CLUSTER_NAME="${BRANCH_NAME,,}-$RANDOM-$BDD_NAME"
+export URANDOM=$(tr -dc 'a-z0-9' < /dev/urandom | head -c6)
+export CLUSTER_NAME="${BRANCH_NAME,,}-$URANDOM-$BDD_NAME"
 export ZONE=europe-west1-c
 export LABELS="branch=${BRANCH_NAME,,},cluster=$BDD_NAME,create-time=${CREATED_TIME,,}"
 


### PR DESCRIPTION
The most common cause of merge conflicts preventing PR in cluster repository is from releases.yaml. Only updating this file in the jx-boot job should prevent this problem.

Also I don't think jx-boot should ever do force push, but if it does it certainly shouldn't overwrite unknown commits

Fixes jenkins-x/jx#8247