### PR TITLE
fix: remove cdf update charts

### DIFF
--- a/.github/workflows/update-charts/updatebot.yaml
+++ b/.github/workflows/update-charts/updatebot.yaml
@@ -8,7 +8,7 @@ spec:
         - versionStream:
             kind: charts
             include:
-              - cdf/*
+              #- cdf/*
               - jenkins-x/*
               - jx3/*
               - jxgh/*


### PR DESCRIPTION
actually we don't want this on at the minute because the tekton helm chart old versions are higher (because we used to version by app version rather than chart version)