### PR TITLE
fix: increase BDD test timeout

### DIFF
--- a/.lighthouse/jenkins-x/bdd/terraform-ci.sh
+++ b/.lighthouse/jenkins-x/bdd/terraform-ci.sh
@@ -234,7 +234,7 @@ then
     jxTestCommand() {
         jx test create -f /workspace/source/.lighthouse/jenkins-x/bdd/$TERRAFORM_FILE --no-watch-job
         tf_resource=tf-${REPO_NAME}-pr${PULL_NUMBER}-${JOB_NAME}-${BUILD_NUMBER}
-        aborttime=$(( $(date +%s) + 3600 ))
+        aborttime=$(( $(date +%s) + 5400 ))
         while ! kubectl get terraforms.tf.isaaguilar.com $tf_resource -ojsonpath='{.status.phase}' | grep -q completed
         do
             if [[ $(date +%s) > $aborttime ]]


### PR DESCRIPTION
Trying to avoid timeout when the test really did succeed:

https://dashboard-jx.infra.jenkins-x.rocks/ns-jx/jenkins-x/jx3-versions/PR-3719/2