### PR TITLE
feat: add cluster node clientID to dns secret for Azure

### DIFF
--- a/charts/bitnami/external-dns/secret-schema.yaml
+++ b/charts/bitnami/external-dns/secret-schema.yaml
@@ -16,7 +16,8 @@ spec:
               "resourceGroup": {{ .Requirements.cluster.azure.dns.resourceGroup }},
               "subscriptionId": {{ .Requirements.cluster.azure.dns.subscriptionId }},
               "tenantId": {{ .Requirements.cluster.azure.dns.tenantId }},
-              "useManagedIdentityExtension": true
+              "useManagedIdentityExtension": true,
+              "userAssignedIdentityID": {{ .Requirements.cluster.azure.clusterNodes.clientID }}
             {{- end }}
             {{- end }}
             }

--- a/charts/bitnami/external-dns/values.yaml.gotmpl
+++ b/charts/bitnami/external-dns/values.yaml.gotmpl
@@ -22,6 +22,7 @@ azure:
   tenantId: {{ .Values.jxRequirements.cluster.azure.dns.tenantId }}
   subscriptionId: {{ .Values.jxRequirements.cluster.azure.dns.subscriptionId }}
   useManagedIdentityExtension: true
+  userAssignedIdentityID: {{ .Values.jxRequirements.cluster.azure.clusterNodes.clientID }}
 {{- end }}
 
 rbac:


### PR DESCRIPTION
Adds the cluster nodes client ID to the external DNS secret. Stops external dns erroring if multiple service principals are found.