### PR TITLE
feat: upgrade observability stack: loki

### DIFF
--- a/charts/grafana/loki/defaults.yaml
+++ b/charts/grafana/loki/defaults.yaml
@@ -1,1 +1,1 @@
-version: 2.5.0
+version: 5.20.0

--- a/charts/grafana/loki/values.yaml
+++ b/charts/grafana/loki/values.yaml
@@ -3,11 +3,13 @@
 persistence:
   enabled: true
 
-config:
+loki:
   # configure a 30 days retention by default
   # note that data might be available for up to 60 days, because of the internal implementation
   # see https://grafana.com/docs/loki/v2.2.0/operations/storage/retention/
   # and https://grafana.com/docs/loki/v2.2.0/operations/storage/table-manager/
-  table_manager:
-    retention_deletes_enabled: true
-    retention_period: 720h
+  config: |
+    compactor:
+      retention_enabled: true
+    limits_config:
+      retention_period: 720h


### PR DESCRIPTION
- upgrade loki to up to date version (maintain consistency)

```loki:
  # configure a 30 days retention by default
  # note that data might be available for up to 60 days, because of the internal implementation
  # see https://grafana.com/docs/loki/v2.2.0/operations/storage/retention/
  # and https://grafana.com/docs/loki/v2.2.0/operations/storage/table-manager/
  config: |
    compactor:
      retention_enabled: true
    limits_config:
      retention_period: 720h
```
In version 2.9.0 it is recommended to move away from table manager to manage the retention policy on logs (changes in this PR) https://grafana.com/docs/loki/latest/setup/upgrade/

```
Relying on retention with the configs retention_deletes_enabled and retention_period
The second and recommended solution, is to use deletes via the compactor:
compactor:
  retention_enabled: true
limits_config:
  retention_period: [30d]
```