### PR TITLE
feat: upgrade Loki charts

### DIFF
--- a/charts/grafana/loki/defaults.yaml
+++ b/charts/grafana/loki/defaults.yaml
@@ -1,1 +1,1 @@
-version: 2.5.0
+version: 5.36.3

--- a/charts/grafana/loki/values.yaml
+++ b/charts/grafana/loki/values.yaml
@@ -5,11 +5,19 @@ loki:
   auth_enabled: false
   commonConfig:
     replication_factor: 1
+  storage:
+    type: 'filesystem'
+    filesystem:
+      rules_directory: /loki/rules
   compactor:
     retention_enabled: true
   limits_config:
     retention_period: 720h
-
+# enable single-binary statefulset
+singleBinary:
+  replicas: 1
+  persistence:
+    enable: true
 # disable unnecessary deployments that comes with Loki Helm 3.0.0+
 rbac:
   pspEnabled: false

--- a/charts/grafana/loki/values.yaml
+++ b/charts/grafana/loki/values.yaml
@@ -1,3 +1,5 @@
+# https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml
+
 # loki config generation
 loki:
   auth_enabled: false

--- a/charts/grafana/loki/values.yaml
+++ b/charts/grafana/loki/values.yaml
@@ -1,13 +1,36 @@
-# https://github.com/grafana/helm-charts/blob/loki-2.5.0/charts/loki/values.yaml
-
-persistence:
-  enabled: true
-
-config:
-  # configure a 30 days retention by default
-  # note that data might be available for up to 60 days, because of the internal implementation
-  # see https://grafana.com/docs/loki/v2.2.0/operations/storage/retention/
-  # and https://grafana.com/docs/loki/v2.2.0/operations/storage/table-manager/
-  table_manager:
-    retention_deletes_enabled: true
+# loki config generation
+loki:
+  auth_enabled: false
+  commonConfig:
+    replication_factor: 1
+  storage:
+    type: 'filesystem'
+    filesystem:
+      rules_directory: /loki/rules
+  compactor:
+    retention_enabled: true
+  limits_config:
     retention_period: 720h
+# enable single-binary statefulset
+singleBinary:
+  replicas: 1
+  persistence:
+    enable: true
+# disable unnecessary deployments that comes with Loki Helm 3.0.0+
+rbac:
+  pspEnabled: false
+monitoring:
+  dashboards:
+    enabled: false
+  selfMonitoring:
+    enabled: false
+    grafanaAgent:
+      installOperator: false
+  lokiCanary:
+    enabled: false
+test:
+  enabled: false
+metricsInstance:
+  enabled: false
+gateway:
+  enabled: false

--- a/charts/grafana/loki/values.yaml
+++ b/charts/grafana/loki/values.yaml
@@ -5,19 +5,11 @@ loki:
   auth_enabled: false
   commonConfig:
     replication_factor: 1
-  storage:
-    type: 'filesystem'
-    filesystem:
-      rules_directory: /loki/rules
   compactor:
     retention_enabled: true
   limits_config:
     retention_period: 720h
-# enable single-binary statefulset
-singleBinary:
-  replicas: 1
-  persistence:
-    enable: true
+
 # disable unnecessary deployments that comes with Loki Helm 3.0.0+
 rbac:
   pspEnabled: false


### PR DESCRIPTION
#### Issue:
- JX-Observability charts are out of date and need updating to avoid drift

#### Fix:
- Upgrade Loki from helm version 2.5.0 > 5.36.3
- Important to note that there are a few changes with how Loki is deployed and has been added to the PR
- With the upgrade, the current statefulset will be removed and re-added (pvc will be claimed by new statefulset)
- The upgrade comes with a few deployments that are defaulted to true, therefore changed to false as unnecessary. 
- offer single binary deployment - easy to customise with k8s config.

#### Next Tasks:
- Update Grafana/Promtail/Prometheus