### PR TITLE
feat: upgrade promtail helm v6.15.3

### DIFF
--- a/charts/grafana/promtail/defaults.yaml
+++ b/charts/grafana/promtail/defaults.yaml
@@ -1,1 +1,1 @@
-version: 3.5.0
+version: 6.15.3


### PR DESCRIPTION
#### Issue:
- Promtail out of date

#### Fix: 
- Upgrade Promtail from 3.5.0 > 6.15.3
- No changes needed - upgrade regen and worked properly on a test cluster