### PR TITLE
feat: compare changes in current with master branch to get selectors

### DIFF
--- a/src/Makefile.mk
+++ b/src/Makefile.mk
@@ -83,7 +83,7 @@ HELMFILE_TEMPLATE_FLAGS ?=
 # HELMFILE_USE_SELECTORS = true
 HELMFILE_USE_SELECTORS ?= false
 CLEAN_OUTPUT_DIR ?= $(if $(findstring true,$(HELMFILE_USE_SELECTORS)),,$(OUTPUT_DIR)/*/*/)
-HELMFILE_GLOBAL_FLAGS += $(if $(findstring true,$(HELMFILE_USE_SELECTORS)),$(shell versionStream/src/get-selectors-and-clean.sh $(OUTPUT_DIR)),)
+HELMFILE_GLOBAL_FLAGS += $(if $(findstring true,$(HELMFILE_USE_SELECTORS)),$(shell versionStream/src/get-selectors-and-clean.sh $(OUTPUT_DIR)) --allow-no-matching-release,)
 
 .PHONY: clean
 clean:

--- a/src/get-selectors-and-clean.sh
+++ b/src/get-selectors-and-clean.sh
@@ -3,26 +3,25 @@
 OUTPUT_DIR=$1
 
 SELECTOR=""
-if ! git log -m -1 --name-only --pretty=format: | grep -qv "^helmfiles/"; then
-  changedNamespaces=$(git log -m -1 --name-only --pretty=format: | grep "^helmfiles/" | cut -d "/" -f 2 | sort -u)
-  if echo "$changedNamespaces" | grep -q ^jx$; then
-    >&2 echo jx namespace changed, no selectors added
-  else
-    for namespace in ${changedNamespaces}; do
-      SELECTOR="${SELECTOR} --selector namespace=${namespace}"
-      rm -rf ${OUTPUT_DIR}/cluster/namespaces/${namespace}.yaml
-      rm -rf ${OUTPUT_DIR}/cluster/resources/${namespace}
-      rm -rf ${OUTPUT_DIR}/customresourcedefinitions/${namespace}
-      rm -rf ${OUTPUT_DIR}/namespaces/${namespace}
-    done
-    >&2 echo helmfile with selector ${SELECTOR}
-  fi
+defaultBranch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+
+if git log -m HEAD ^"$defaultBranch" --name-only --pretty=format: | grep -q "^helmfiles/"; then
+  changedNamespaces=$(git log -m HEAD ^"$defaultBranch" --name-only --pretty=format: | grep "^helmfiles/" | cut -d "/" -f 2 | sort -u)
+  for namespace in ${changedNamespaces}; do
+    SELECTOR="${SELECTOR} --selector namespace=${namespace}"
+    rm -rf ${OUTPUT_DIR}/cluster/namespaces/${namespace}.yaml
+    rm -rf ${OUTPUT_DIR}/cluster/resources/${namespace}
+    rm -rf ${OUTPUT_DIR}/customresourcedefinitions/${namespace}
+    rm -rf ${OUTPUT_DIR}/namespaces/${namespace}
+  done
+  >&2 echo helmfile with selector ${SELECTOR}
 fi
 
 if [ -z "${SELECTOR}" ]; then
   >&2 echo helmfile without selector
   rm -rf ${OUTPUT_DIR}/*/*/
-  jx gitops repository create >&2
 fi
+
+jx gitops repository create >&2
 
 echo ${SELECTOR}


### PR DESCRIPTION
Previously only the most recent commit was used to identify changes to a helmfile and identify the selectors to use. This caused issues where if a second commit was made altering a different helmfile then the first helmfile would be ignored. This is fixed by comparing changes to the helmfiles in the current branch with what is currently in the default branch.


 The `--allow-no-matching-release` flag has also been added. This stops the templating from erroring in the case where a namespace is removed (selector applied to the helmfile flags no longer exists). 