### PR TITLE
fix: promote-vs.sh

### DIFF
--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -49,7 +49,7 @@ spec:
                 ./.lighthouse/jenkins-x/release/update-jx-cask.sh || echo Update of cask failed
             - name: changelog
               resources: {}
-            - image: ghcr.io/jenkins-x/jx:3.10.144
+            - image: ghcr.io/jenkins-x/jx-boot:3.10.144
               name: promote-vs
               resources: {}
               script: |

--- a/.lighthouse/jenkins-x/release/promote-vs.sh
+++ b/.lighthouse/jenkins-x/release/promote-vs.sh
@@ -37,7 +37,6 @@ function upgradeClusterRepo {
   cd "$1"
   echo "recreating a clean version stream"
   rm -rf versionStream .lighthouse/jenkins-x .lighthouse/Kptfile
-  jx gitops kpt update || true
   kpt pkg get https://github.com/jenkins-x/jx3-pipeline-catalog.git/$2/.lighthouse/jenkins-x .lighthouse/jenkins-x
   kpt pkg get https://github.com/jenkins-x/jxr-versions.git/ versionStream
   rm -rf versionStream/jenkins*.yml versionStream/jx versionStream/.github versionStream/.pre* versionStream/.secrets* versionStream/OWNER* versionStream/.lighthouse
@@ -45,6 +44,7 @@ function upgradeClusterRepo {
   jx gitops helmfile report
   git add * .lighthouse || true
   git commit -a -m "chore: upgrade version stream" || true
+  jx gitops kpt update && git add . && git commit -a -m "chore: upgrade other kpt packages" || true
   git push || true
 }
 


### PR DESCRIPTION
We have multiple "general purpose" jx images. I'm trying to reduce that since it easily causes version mismatch of installed tools. I currently noticed that ghcr.io/jenkins-x/jx and ghcr.io/jenkins-x/jx-boot have different version of kpt...

 Since jx-boot is used a lot I don't see much point in using it more; nodes are likely to have downloaded it anyway.