### PR TITLE
fixe: remove non existing parameter --deadline from golangci-lint

### DIFF
--- a/git/github.com/jenkins-x/jx3-pipeline-catalog.yml
+++ b/git/github.com/jenkins-x/jx3-pipeline-catalog.yml
@@ -1,5 +1,5 @@
 gitUrl: https://github.com/jenkins-x/jx3-pipeline-catalog.git
-version: f1de3b920fd3df4fd9e5d268c95344ea3b987e0a
+version: 32a17cb530d77034d460cf73cca2a8cf7adcf332
 
 
 


### PR DESCRIPTION
related to jenkins-x/jx#8670