### PR TITLE
fix: restore switch from pusher-wave to wave

### DIFF
--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -16,6 +16,6 @@ jobs:
           XDG_CONFIG_HOME: /tmp/git
           GIT_TOKEN: ${{ secrets.GIT_BOT_TOKEN }}
         name: updatebot
-        uses: docker://ghcr.io/jenkins-x/jx-updatebot:0.0.75
+        uses: docker://ghcr.io/jenkins-x/jx-updatebot:0.4.24
         with:
           args: pr -c .github/workflows/update-charts/updatebot.yaml --no-version --git-credentials --git-token ${{ secrets.GIT_BOT_TOKEN }} --git-username jenkins-x-bot-test --git-user-name jenkins-x-bot-test

--- a/charts/jxgh/pusher-wave/defaults.yaml
+++ b/charts/jxgh/pusher-wave/defaults.yaml
@@ -1,1 +1,2 @@
-version: 0.4.21
+replacementChart: wave
+replacementChartPrefix: wave-k8s

--- a/charts/wave-k8s/wave/defaults.yaml
+++ b/charts/wave-k8s/wave/defaults.yaml
@@ -1,3 +1,3 @@
 gitUrl: https://github.com/wave-k8s/wave
 namespace: secret-infra
-version: 4.1.0
+version: 4.2.0


### PR DESCRIPTION
The action Update charts in the version stream [partially reverted](https://github.com/jenkins-x/jx3-versions/pull/3909) [my change](https://github.com/jenkins-x/jx3-versions/pull/3881). This PR fixes this, upgrades wave and hopefully prevents further unwanted changes by the action.

