### PR TITLE
feat: add maintained cluster autoscaler helm chart

### DIFF
--- a/charts/autoscaler/cluster-autoscaler/defaults.yaml
+++ b/charts/autoscaler/cluster-autoscaler/defaults.yaml
@@ -1,0 +1,3 @@
+gitUrl: https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler
+namespace: kube-system
+version: 9.37.0

--- a/charts/autoscaler/cluster-autoscaler/values.yaml.gotmpl
+++ b/charts/autoscaler/cluster-autoscaler/values.yaml.gotmpl
@@ -1,0 +1,15 @@
+{{- if eq .Values.jxRequirements.cluster.provider "eks" }}
+autoDiscovery:
+  enabled: true
+  clusterName: {{ .Values.jxRequirements.cluster.clusterName }}
+awsRegion: {{ .Values.jxRequirements.cluster.region }}
+{{- end }}
+
+rbac:
+  create: true
+{{- if and (hasKey .Values.jxRequirements.cluster "project") (hasKey .Values.jxRequirements.cluster "clusterName") (eq .Values.jxRequirements.cluster.provider "eks") }}
+  serviceAccount:
+    name: cluster-autoscaler
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.project }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-cluster-autoscaler-cluster-autoscaler
+{{- end }}

--- a/charts/repositories.yml
+++ b/charts/repositories.yml
@@ -50,3 +50,6 @@ repositories:
 - prefix: wave-k8s
   urls:
   - https://wave-k8s.github.io/wave/
+- prefix: autoscaler
+  urls:
+  - https://kubernetes.github.io/autoscaler


### PR DESCRIPTION
https://github.com/helm/charts/tree/master/stable/cluster-autoscaler is frozen since a long time. his PR adds the maintained helm chart for cluster autoscaler.