### PR TITLE
fix: mark jx release as latest

### DIFF
--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -27,7 +27,7 @@ spec:
               resources: {}
             - name: jx-variables
               resources: {}
-            - image: ghcr.io/jenkins-x/jx-scm:0.1.5
+            - image: ghcr.io/jenkins-x/jx-scm:0.2.48
               name: release-jx-cli
               resources: {}
               env:
@@ -38,13 +38,15 @@ spec:
                     secretKeyRef:
                       name: tekton-git
                       key: password
+                - name: GIT_TOKEN
+                  value: $(GITHUB_TOKEN)
               script: |
                 #!/bin/sh
                 export JX_VERSION=$(grep 'version: ' packages/jx.yml | awk '{ print $2}')
                 export LH_VERSION=$(grep 'version: ' charts/jxgh/lighthouse/defaults.yaml | awk '{ print $2}')
                 echo "using versions JX: ${JX_VERSION} lighthouse: ${LH_VERSION}"
-                jx scm release update --owner jenkins-x --name jx --tag v$JX_VERSION --prerelease=false --kind github --server https://github.com --token $GITHUB_TOKEN
-                jx scm release update --owner jenkins-x --name lighthouse --tag v$LH_VERSION --prerelease=false --kind github --server https://github.com --token $GITHUB_TOKEN
+                jx scm release update --owner jenkins-x --name jx --tag v$JX_VERSION --prerelease=false --kind github --server https://github.com
+                jx scm release update --owner jenkins-x --name lighthouse --tag v$LH_VERSION --prerelease=false --kind github --server https://github.com
                 ./.lighthouse/jenkins-x/release/promote-jx-website.sh
                 ./.lighthouse/jenkins-x/release/update-jx-cask.sh || echo Update of cask failed
             - name: changelog

--- a/.lighthouse/jenkins-x/release/promote-vs.sh
+++ b/.lighthouse/jenkins-x/release/promote-vs.sh
@@ -9,9 +9,9 @@ declare -a repos=(
   # vanilla
   "jx3-kubernetes" "jx3-kubernetes-bbc" "jx3-kubernetes-istio" "jx3-kubernetes-minio" "jx3-kubernetes-vault" "jx3-kind" "jx3-kind-gitea" "jx3-minikube" "jx3-docker-vault" "jx3-k3s-vault"
   # GKE
-  "jx3-gke-vault" "jx3-gke-gsm" "jx3-gke-gsm-gitea" "jx3-gke-gcloud-vault"
+  "jx3-gke-vault" "jx3-gke-gsm" "jx3-gke-gsm-gitea"
   # EKS
-  "jx3-eks-asm" "jx3-eks-vault"  
+  "jx3-eks-asm" "jx3-eks-vault"
   # Azure
   "jx3-azure-vault" "jx3-azure-akv"
   # OpenShift


### PR DESCRIPTION
also reduce risk of leaking secret in logs
stop trying to upgrade archived repository