### PR TITLE
fix: schema problem with cert-manager

### DIFF
--- a/charts/jetstack/cert-manager/defaults.yaml
+++ b/charts/jetstack/cert-manager/defaults.yaml
@@ -1,3 +1,4 @@
 gitUrl: https://github.com/jetstack/cert-manager
 namespace: cert-manager
-version: v1.16.1
+version: v1.15.3
+upperLimit: "1.16.0"


### PR DESCRIPTION
Until support for not adding jx-values.yaml is added we need to stay on a version below 1.16

See https://kubernetes.slack.com/archives/C9MBGQJRH/p1728626859862409

I have started to work on a [proper solution](https://github.com/jenkins-x/jx-helpers/pull/419), but until then we need to downgrade.