### PR TITLE
chore: Add missing prefix for ingress-nginx and fix gitUrl

### DIFF
--- a/charts/ingress-nginx/ingress-nginx/defaults.yaml
+++ b/charts/ingress-nginx/ingress-nginx/defaults.yaml
@@ -1,4 +1,4 @@
 component: ingress-nginx
-gitUrl: https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx
+gitUrl: https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx
 namespace: nginx
 version: 4.7.0

--- a/charts/repositories.yml
+++ b/charts/repositories.yml
@@ -56,3 +56,6 @@ repositories:
 - prefix: bank-vaults
   urls:
   - oci://ghcr.io/bank-vaults/helm-charts
+- prefix: ingress-nginx
+  urls:
+  - https://kubernetes.github.io/ingress-nginx


### PR DESCRIPTION
Currently chart upgrade for ingress-nginx does not work https://github.com/jenkins-x/jx3-versions/actions/runs/12681762739/job/35346055685#step:4:16:

```
repository prefix ingress-nginx has no URL in charts/repositories.yml
```

This should hopefully fix it.