### PR TITLE
fix: correct env variables for keeper

### DIFF
--- a/charts/jxgh/lighthouse/values.yaml.gotmpl
+++ b/charts/jxgh/lighthouse/values.yaml.gotmpl
@@ -42,10 +42,11 @@ keeper:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9090"
   env:
-    LIGHTHOUSE_TRIGGER_ON_MISSING: enable
 {{- if eq .Values.jxRequirements.cluster.gitKind "bitbucketserver" }}
     GIT_CLONE_PATH_PREFIX: "scm"
 {{- end }}
+    # the pipeline catalog version streams:
+    LIGHTHOUSE_VERSIONSTREAM_JENKINS_X_JX3_PIPELINE_CATALOG: {{ readFile "../../../git/github.com/jenkins-x/jx3-pipeline-catalog.yml" | fromYaml | get "version" | quote }}
 
 vault:
 {{- if eq .Values.jxRequirements.secretStorage "vault" }}


### PR DESCRIPTION
LIGHTHOUSE_VERSIONSTREAM_JENKINS_X_JX3_PIPELINE_CATALOG is missing, which give warning logs 

To enable LIGHTHOUSE_TRIGGER_ON_MISSING the variable should not be set (no, not very logical). The value enable is interpreted as the name of a repository to disable trigger on missing for.