### PR TITLE
fix: exclude automatic lighthouse upgrade

### DIFF
--- a/.github/workflows/update-charts/updatebot.yaml
+++ b/.github/workflows/update-charts/updatebot.yaml
@@ -9,8 +9,6 @@ spec:
             kind: charts
             include:
               # - cdf/*
-              - jenkins-x/*
-              - jx3/*
               - jxgh/*
               # Cert manager
               # - jetstack/*
@@ -18,3 +16,6 @@ spec:
               - external-secrets/*
               # nginx
               - ingress-nginx/*
+            # Exclude lighthouse until tekton upgrade is done
+            exclude:
+            - jxgh/lighthouse


### PR DESCRIPTION
It's not really needed since updatebot is run in the lighthouse release pipeline as well.

Also removing repository prefixes that aren't used anymore