### PR TITLE
bump jx-kh-check jx chart to 0.0.80

### DIFF
--- a/charts/jxgh/health-checks-jx/defaults.yaml
+++ b/charts/jxgh/health-checks-jx/defaults.yaml
@@ -1,3 +1,3 @@
 gitUrl: https://github.com/jenkins-x-plugins/jx-kh-check
-version: 0.0.78
+version: 0.0.80
 namespace: jx


### PR DESCRIPTION
The current version (0.0.78) is busted due to the chart trying to provision a misconfigured `KuberhealthyCheck` (CRD: `khchecks.comcast.github.io`) resource:

```
Error from server: failed to create typed patch object (jx/jx-webhook-events; comcast.github.io/v1, Kind=KuberhealthyCheck): .spec.podSpec.containers[0].restartPolicy: field not declared in schema
Error from server: failed to create typed patch object (jx/jx-webhook; comcast.github.io/v1, Kind=KuberhealthyCheck): .spec.podSpec.containers[0].restartPolicy: field not declared in schema
```
`0.0.80` resolves this issue.

I believe this needs to be adjusted as needed within this repo to prevent `jx-updatebot` from downgrading the verison by accident, which keeps occasionally happening to an environment of ours downstream, even though we set a lock on the helm version. (Not sure why though, but hoping this PR resolves this issue for us.)