### PR TITLE
fix: disable nginx jobs

### DIFF
--- a/charts/ingress-nginx/ingress-nginx/values.yaml.gotmpl
+++ b/charts/ingress-nginx/ingress-nginx/values.yaml.gotmpl
@@ -1,6 +1,13 @@
 fullnameOverride: ingress-nginx
 
 controller:
+  admissionWebhooks:
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+    certManager:
+      enabled: true
+{{- else }}
+    enabled: false
+{{- end }}
   replicaCount: 3
   extraArgs:
     publish-service: nginx/ingress-nginx-controller


### PR DESCRIPTION
They don't play well with `helm template`.
 If cert-manager is installed use that to setup secrets instead otherwise skip the admission webhook