### PR TITLE
fix: increase pv size for tf operator

### DIFF
--- a/.lighthouse/jenkins-x/bdd/terraform.yaml.gotmpl
+++ b/.lighthouse/jenkins-x/bdd/terraform.yaml.gotmpl
@@ -1,7 +1,7 @@
 apiVersion: tf.isaaguilar.com/v1alpha1
 kind: Terraform
 spec:
-  persistentVolumeSize: "4Gi"
+  persistentVolumeSize: "10Gi"
   env:
   - name: KUBECONFIG
     value: "/tmp/kubecfg"


### PR DESCRIPTION
Seeing issues in gsm where the pv for the tf operator was running out of space.

```
│ Error: Failed to install provider
│ 
│ Error while installing hashicorp/random v3.8.1: mkdir
│ .terraform/providers/registry.terraform.io/hashicorp/random: no space left
│ on device
╵

╷
│ Error: Failed to install provider
│ 
│ Error while installing hashicorp/local v2.8.0: write
│ .terraform/providers/registry.terraform.io/hashicorp/local/2.8.0/linux_amd64/terraform-provider-local_v2.8.0_x5:
│ no space left on device
╵

╷
│ Error: Failed to install provider
│ 
│ Error while installing hashicorp/google v7.31.0: write
│ .terraform/providers/registry.terraform.io/hashicorp/google/7.31.0/linux_amd64/LICENSE.txt:
│ no space left on device
╵

╷
│ Error: Failed to install provider
│ 
│ Error while installing hashicorp/kubernetes v3.1.0: write
│ .terraform/providers/registry.terraform.io/hashicorp/kubernetes/3.1.0/linux_amd64/terraform-provider-kubernetes_v3.1.0_x5:
│ no space left on device
╵
```