### PR TITLE
feat: add envoy-gateway to jxgh charts

### DIFF
--- a/charts/jxgh/envoy-gateway/defaults.yaml
+++ b/charts/jxgh/envoy-gateway/defaults.yaml
@@ -1,0 +1,2 @@
+gitUrl: https://github.com/jenkins-x-charts/envoy-gateway
+version: 0.1.0

--- a/charts/jxgh/envoy-gateway/values.yaml.gotmpl
+++ b/charts/jxgh/envoy-gateway/values.yaml.gotmpl
@@ -1,0 +1,59 @@
+envoyGateway:
+  gatewayClass:
+    create: true
+    name: envoy-gatewayclass
+    controllerName: gateway.envoyproxy.io/gatewayclass-controller
+
+  gateway:
+    listeners:
+      - name: http
+        port: 80
+        protocol: HTTP
+        allowedRoutes:
+          namespaces:
+            from: All
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+      - name: https
+        port: 443
+        protocol: HTTPS
+        allowedRoutes:
+          namespaces:
+            from: All
+        tls:
+          mode: Terminate
+          certificateRefs:
+            - kind: Secret
+{{- if hasKey .Values.jxRequirements.ingress.tls "secretName" }}
+              name: {{ .Values.jxRequirements.ingress.tls.secretName }}
+{{- else if .Values.jxRequirements.ingress.tls.production }}
+              name: tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-p
+{{- else }}
+              name: tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-s
+{{- end }}
+    httpsRedirect:
+      - http
+{{- else }}
+    httpsRedirect: []
+{{- end }}
+
+  envoyProxy:
+    replicas: 3
+    service:
+{{- if eq .Values.jxRequirements.cluster.provider "kind" }}
+      type: NodePort
+{{- else if hasKey .Values.jxRequirements.ingress "serviceType" }}
+      type: {{ .Values.jxRequirements.ingress.serviceType }}
+{{- else }}
+      type: LoadBalancer
+{{- end }}
+{{- if eq .Values.jxRequirements.cluster.provider "eks" }}
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+        service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
+        service.beta.kubernetes.io/aws-load-balancer-type: nlb
+{{- else if eq .Values.jxRequirements.cluster.provider "aks" }}
+      annotations:
+        service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+{{- else }}
+      annotations: {}
+{{- end }}


### PR DESCRIPTION
### Changes
* Add `envoy-gateway` to `jxgh` charts
* Create a values template for operating with JX Requirements 

### Context

Implements https://github.com/jenkins-x-charts/envoy-gateway with a provider-specific values template provided by `jx-requirements.yaml`.

The template provisions a `GatewayClass`, a `Gateway` with HTTP (and conditionally HTTPS) listeners, and an `EnvoyProxy` whose service type and load-balancer annotations are derived from the cluster provider (kind, eks, aks).

TLS preserves the existing JX cert-manager secret naming convention, so clusters with `ingress.tls.enabled` get HTTPS termination and an HTTP→HTTPS redirect out of the box.