### PR TITLE
chore: upgrade jx3-pipeline-catalog to support go 1.26

### DIFF
--- a/git/github.com/jenkins-x/jx3-pipeline-catalog.yml
+++ b/git/github.com/jenkins-x/jx3-pipeline-catalog.yml
@@ -1,16 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jx3-pipeline-catalog.git
-version: 65879061dd840f7b2979041d45f1c80bb17f4c77
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+version: 5a63e63a1cf89a1d650182d9cc9ef9385aa678c9


### PR DESCRIPTION
Part of fix for jenkins-x/jx#8965