### PR TITLE
chore: upgrade charts

### DIFF
--- a/charts/ingress-nginx-oci/ingress-nginx/defaults.yaml
+++ b/charts/ingress-nginx-oci/ingress-nginx/defaults.yaml
@@ -1,4 +1,5 @@
+Labels: null
 component: ingress-nginx
 gitUrl: https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx
 namespace: nginx
-version: v4.14.0
+version: 0.0.0


### PR DESCRIPTION
* updated chart [ingress-nginx-oci/ingress-nginx](https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx) from `v4.14.0` to `0.0.0`