### PR TITLE
chore: upgrade charts

### DIFF
--- a/charts/cdf/tekton-pipeline/defaults.yaml
+++ b/charts/cdf/tekton-pipeline/defaults.yaml
@@ -1,3 +1,4 @@
+Labels: null
 gitUrl: https://github.com/cdfoundation/tekton-helm-chart
 namespace: tekton-pipelines
-version: 1.12.0
+version: 1.12.2

--- a/charts/ingress-nginx-oci/ingress-nginx/defaults.yaml
+++ b/charts/ingress-nginx-oci/ingress-nginx/defaults.yaml
@@ -1,4 +1,5 @@
+Labels: null
 component: ingress-nginx
 gitUrl: https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx
 namespace: nginx
-version: v4.14.0
+version: v4.15.1

--- a/charts/jxgh/jx-build-controller/defaults.yaml
+++ b/charts/jxgh/jx-build-controller/defaults.yaml
@@ -1,2 +1,3 @@
+Labels: null
 gitUrl: https://github.com/jenkins-x-plugins/jx-build-controller
-version: 0.5.34
+version: 0.5.35

--- a/charts/jxgh/jx-preview/defaults.yaml
+++ b/charts/jxgh/jx-preview/defaults.yaml
@@ -1,2 +1,3 @@
+Labels: null
 gitUrl: https://github.com/jenkins-x/jx-preview
-version: 0.7.8
+version: 0.7.12

--- a/charts/jxgh/jx-test/defaults.yaml
+++ b/charts/jxgh/jx-test/defaults.yaml
@@ -1,2 +1,3 @@
+Labels: null
 gitUrl: https://github.com/jenkins-x-plugins/jx-test
-version: 0.4.11
+version: 0.4.12

--- a/charts/jxgh/jxboot-helmfile-resources/defaults.yaml
+++ b/charts/jxgh/jxboot-helmfile-resources/defaults.yaml
@@ -1,2 +1,3 @@
+Labels: null
 gitUrl: https://github.com/jenkins-x-charts/jxboot-helmfile-resources
-version: 1.2.49
+version: 1.2.54

--- a/charts/jxgh/lighthouse/defaults.yaml
+++ b/charts/jxgh/lighthouse/defaults.yaml
@@ -1,2 +1,3 @@
+Labels: null
 gitUrl: https://github.com/jenkins-x/lighthouse
-version: 1.30.0
+version: 1.30.4


### PR DESCRIPTION
* updated chart [cdf/tekton-pipeline](https://github.com/cdfoundation/tekton-helm-chart) from `1.12.0` to `1.12.2`
* updated chart [ingress-nginx-oci/ingress-nginx](https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx) from `v4.14.0` to `v4.15.1`
* updated chart [jxgh/jx-build-controller](https://github.com/jenkins-x-plugins/jx-build-controller) from `0.5.34` to `0.5.35`
* updated chart [jxgh/jx-preview](https://github.com/jenkins-x/jx-preview) from `0.7.8` to `0.7.12`
* updated chart [jxgh/jx-test](https://github.com/jenkins-x-plugins/jx-test) from `0.4.11` to `0.4.12`
* updated chart [jxgh/jxboot-helmfile-resources](https://github.com/jenkins-x-charts/jxboot-helmfile-resources) from `1.2.49` to `1.2.54`
* updated chart [jxgh/lighthouse](https://github.com/jenkins-x/lighthouse) from `1.30.0` to `1.30.4`