### PR TITLE
feat(jxgh): Gateway API templates; add key in basic auth secret

### DIFF
--- a/charts/jxgh/jx-pipelines-visualizer/values.yaml.gotmpl
+++ b/charts/jxgh/jx-pipelines-visualizer/values.yaml.gotmpl
@@ -1,5 +1,5 @@
 ingress:
-  enabled: true
+  enabled: {{ ne "httproute" .Values.jxRequirements.ingress.kind }}
   annotations:
     # lets enable basic auth by default
 
@@ -25,6 +25,22 @@ ingress:
 {{- else }}
       "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-s": {}
 {{- end }}
+
+gatewayApi:
+  enabled: {{ eq "httproute" .Values.jxRequirements.ingress.kind }}
+  parentRef:
+    name: envoy-gateway
+    namespace: envoy-gateway-system
+    # override the chart default ("https") so the route binds to all Gateway
+    # listeners (http + https), matching behaviour whether or not TLS is enabled
+    sectionName: ""
+  hosts:
+  - "dashboard{{ .Values.jxRequirements.ingress.namespaceSubDomain | default "." }}{{ .Values.jxRequirements.ingress.domain | default "cluster.local" }}"
+  basicAuth:
+    enabled: true
+    kind: envoy
+    # reuse the shared htpasswd secret (see jxboot secret-schema .htpasswd key)
+    existingSecret: jx-basic-auth-htpasswd
 
 {{- if and (eq .Values.jxRequirements.cluster.provider "eks") (hasKey .Values.jxRequirements.cluster "region") }}
 pod:

--- a/charts/jxgh/jxboot-helmfile-resources/secret-schema.yaml
+++ b/charts/jxgh/jxboot-helmfile-resources/secret-schema.yaml
@@ -24,6 +24,16 @@ spec:
       template: |-
         {{ htpasswdExtSecret "jx-basic-auth-user-password" "username" "password" }}
       onlyTemplateIfBlank: true
+    # Envoy Gateway BasicAuth SecurityPolicy requires the htpasswd under a key
+    # named ".htpasswd"; mirrors "auth" so the one secret serves both nginx
+    # Ingress and Gateway API HTTPRoute basic auth.
+    - name: .htpasswd
+      question: the htpasswd format basic auth for Gateway API HTTPRoute
+      help: The htpasswd encoded user and password for Envoy Gateway basic auth
+      retry: true
+      template: |-
+        {{ htpasswdExtSecret "jx-basic-auth-user-password" "username" "password" }}
+      onlyTemplateIfBlank: true
   - name: jenkins-release-gpg
     properties:
     - name: pubring.gpg

--- a/charts/jxgh/lighthouse-webui-plugin/values.yaml.gotmpl
+++ b/charts/jxgh/lighthouse-webui-plugin/values.yaml.gotmpl
@@ -1,7 +1,7 @@
 # https://github.com/jenkins-x-plugins/lighthouse-webui-plugin/blob/main/charts/lighthouse-webui-plugin/values.yaml
 
 ingress:
-  enabled: true
+  enabled: {{ ne "httproute" .Values.jxRequirements.ingress.kind }}
   annotations:
     # lets enable basic auth by default
 
@@ -27,6 +27,20 @@ ingress:
 {{- else }}
       "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-s": {}
 {{- end }}
+
+gatewayApi:
+  enabled: {{ eq "httproute" .Values.jxRequirements.ingress.kind }}
+  parentRef:
+    name: envoy-gateway
+    namespace: envoy-gateway-system
+    # sectionName omitted → attaches to all Gateway listeners (http + https)
+  hosts:
+  - "lighthouse{{ .Values.jxRequirements.ingress.namespaceSubDomain | default "." }}{{ .Values.jxRequirements.ingress.domain | default "cluster.local" }}"
+  basicAuth:
+    enabled: true
+    kind: envoy
+    # reuse the shared htpasswd secret (see jxboot secret-schema .htpasswd key)
+    existingSecret: jx-basic-auth-htpasswd
 
 config:
 


### PR DESCRIPTION
### Changes

* add `.htpasswd` key to `jx-basic-auth-user-password` secret in `charts/jxgh/jxboot-helmfile-resources/secret-schema.yaml`
* Set `gatewayApi` block for `jxgh/lighthouse-webui-plugin` and `jxgh/jx-pipelines-visualizer` charts

### Context

Add Gateway API templates for `lighthouse-webui-plugin` and `jx-pipelines-visualizer` charts. When `jxRequirements.ingress.kind: httproute`, then ingress is disabled and Gateway API deployed for these charts.

These both use basicAuth, which is requires a `.htpasswd` key to be set in the basic auth secret, requiring an addition to `charts/jxgh/jxboot-helmfile-resources/secret-schema.yaml` as well

Part of https://github.com/jenkins-x/jx/issues/8962 - `jxboot-helmfile-resources` directly templates from jx requirements, so is not needed here